### PR TITLE
templating to enforce sys property presence

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,13 @@ if (System.getenv('CI') == null) {
 }
 task version {
 	doLast {
-		println "to release a new version run:"
-		println "CI=true ./gradlew reckonTagPush -Preckon.scope=[major,minor,patch] -Preckon.stage=[rc,final]"
+		if (project.findProperty('reckon.stage')) {
+			println "to tag and release a new version use:"
+			println "git tag -a '${project.version}' -m '${project.version}' && git push origin '${project.version}'"
+		} else {
+			println "to figure out the next version run:"
+			println "CI=true ./gradlew version -Preckon.scope=[major,minor,patch] -Preckon.stage=[rc,final]"
+		}
 	}
 }
 reckonTagCreate.dependsOn "build"

--- a/confij-core/src/main/java/ch/kk7/confij/template/DefaultResolver.java
+++ b/confij-core/src/main/java/ch/kk7/confij/template/DefaultResolver.java
@@ -1,6 +1,7 @@
 package ch.kk7.confij.template;
 
 import ch.kk7.confij.binding.ConfijBindingException;
+import ch.kk7.confij.common.ConfijException;
 import ch.kk7.confij.tree.ConfijNode;
 import lombok.ToString;
 
@@ -83,12 +84,19 @@ public class DefaultResolver implements VariableResolver {
 		String path = targetUri.getSchemeSpecificPart();
 		switch (scheme) {
 			case "env":
-				return Optional.ofNullable(System.getenv(path));
+				return mandatory(uriStr, System.getenv(path));
 			case "sys":
-				return Optional.ofNullable(System.getProperty(path));
+				return mandatory(uriStr, System.getProperty(path));
 			default:
 				return Optional.empty();
 		}
+	}
+
+	private static Optional<String> mandatory(String uriStr, String value) {
+		if (value == null) {
+			throw new ConfijException("templating failed, since we lack a mandatory value for '{}'", uriStr);
+		}
+		return Optional.of(value);
 	}
 
 	protected void clearCache() {

--- a/confij-core/src/test/java/ch/kk7/confij/SysPropertyAssertions.java
+++ b/confij-core/src/test/java/ch/kk7/confij/SysPropertyAssertions.java
@@ -1,0 +1,37 @@
+package ch.kk7.confij;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Supplier;
+
+public interface SysPropertyAssertions {
+	default <T> T withSysProperty(Supplier<T> supplier, String... overrides) {
+		Map<String, String> override = new HashMap<>();
+		for (int i = 0; i < overrides.length; i+=2) {
+			override.put(overrides[i], overrides[i + 1]);
+		}
+		return withSysProperty(supplier, override);
+	}
+
+	default <T> T withSysProperty(Supplier<T> supplier, Map<String, String> override) {
+		Properties sysProperties = System.getProperties(); // a reference, not a copy!
+		Properties clone = new Properties();
+		clone.putAll(sysProperties);
+
+		override.forEach((k, v) -> {
+			if (v == null) {
+				sysProperties.remove(k);
+			} else {
+				sysProperties.put(k, v);
+			}
+		});
+		try {
+			return supplier.get();
+		} finally {
+			// restore settings
+			sysProperties.clear();
+			sysProperties.putAll(clone);
+		}
+	}
+}


### PR DESCRIPTION
missing sys or env vars in template variables will result in an exception, instead of attempting to load it as a tree node.
minor: howto git release (to allow for signed tags) with `./gradlew version`.