### PR TITLE
dependency version bumps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
     organization: keykey7-github
 
 script:
-  - ./gradlew --no-daemon --scan -s build publishToMavenLocal sonarqube
+  - ./gradlew --no-daemon -s build publishToMavenLocal sonarqube
 
 deploy:
   - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ git:
 
 jdk:
   - oraclejdk8
-  - oraclejdk9
+  - oraclejdk11
 
 addons:
   sonarcloud:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ git:
   depth: false
 
 jdk:
-  - oraclejdk8
-  - oraclejdk11
+  - openjdk8
+  - openjdk11
 
 addons:
   sonarcloud:
@@ -38,10 +38,9 @@ deploy:
       jdk: oraclejdk8
 
 before_cache:
-- rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-- rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
-  - $HOME/.gradle/caches/
-  - $HOME/.gradle/wrapper/
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/

--- a/build.gradle
+++ b/build.gradle
@@ -11,10 +11,9 @@ buildscript {
 
 plugins {
 	id 'org.ajoberstar.reckon' version '0.9.0'
-	id 'com.gradle.build-scan' version '2.1'
 	id 'net.ltgt.apt-idea' version '0.21'
-	id 'com.github.ben-manes.versions' version '0.20.0' // task: dependencyUpdates
-	id 'org.sonarqube' version '2.7'
+	id 'com.github.ben-manes.versions' version '0.27.0' // task: dependencyUpdates
+	id 'org.sonarqube' version '2.8'
 }
 
 reckon {
@@ -40,26 +39,23 @@ reckonTagCreate.dependsOn "build"
 allprojects {
 	repositories {
 		jcenter()
-
-		maven { url 'http://ci.hibernate.org/plugin/repository/project/hibernate-validator-master/LastSuccessful/repository' }
-		// broken by hibernate. We therefore use a custom (idiotic) ivy repo pattern to get a snapshot version
-		ivy {
-			url 'http://ci.hibernate.org/plugin/repository/project/hibernate-validator-master/LastSuccessful/repository'
-			patternLayout {
-				m2compatible = true
-				artifact '[organisation]/[module]/[revision]/[artifact]-[revision](.[ext])'
-			}
-		}
 	}
 	apply plugin: 'idea'
 	group 'ch.kk7'
 	version rootProject.version
-	dependencyUpdates.revision = 'release'
 }
 
-buildScan {
-	termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-	termsOfServiceAgree = 'yes'
+dependencyUpdates.resolutionStrategy {
+	componentSelection { rules ->
+		rules.all { ComponentSelection selection ->
+			boolean rejected = ['alpha', 'beta', 'rc', 'cr', 'm', 'preview', 'b', 'ea'].any { qualifier ->
+				selection.candidate.version ==~ /(?i).*[.-]$qualifier[.\d-+]*/
+			}
+			if (rejected) {
+				selection.reject('Release candidate')
+			}
+		}
+	}
 }
 
 subprojects {
@@ -73,27 +69,24 @@ subprojects {
 
 	dependencies {
 		// TODO: upgrade: https://github.com/google/auto/pull/657
-		def autoServiceVersion = "1.0-rc4"
+		def autoServiceVersion = "1.0-rc6"
 		compileOnly "com.google.auto.service:auto-service:${autoServiceVersion}"
 		annotationProcessor "com.google.auto.service:auto-service:${autoServiceVersion}"
 		testCompileOnly "com.google.auto.service:auto-service:${autoServiceVersion}"
 		testAnnotationProcessor "com.google.auto.service:auto-service:${autoServiceVersion}"
 
-		def lombokVersion = "1.18.6"
+		def lombokVersion = "1.18.10"
 		compileOnly "org.projectlombok:lombok:${lombokVersion}"
 		annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 		testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
 		testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
-		def junitVersion = '5.4.0'
+		def junitVersion = '5.5.2'
 		testImplementation "org.junit.jupiter:junit-jupiter-params:${junitVersion}"
 		testImplementation "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
-		testImplementation('org.junit-pioneer:junit-pioneer:0.3.0') {
-			exclude group: 'org.junit.jupiter'
-		}
-		testImplementation "org.assertj:assertj-core:3.12.0"
+		testImplementation "org.assertj:assertj-core:3.14.0"
 
-		testRuntime 'ch.qos.logback:logback-classic:1.2.3'
+		runtimeOnly 'ch.qos.logback:logback-classic:1.2.3'
 	}
 
 	test {
@@ -107,11 +100,6 @@ subprojects {
 			}
 		}
 	}
-}
-
-wrapper {
-	gradleVersion = '5.2.1'
-	distributionType = Wrapper.DistributionType.ALL
 }
 
 // coverage

--- a/build.gradle
+++ b/build.gradle
@@ -3,17 +3,15 @@ buildscript {
 		mavenLocal()
 		jcenter()
 	}
-	dependencies {
-		classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-		classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.9.2' // NOT: 1.6.0 due to conflicts with 'org.ajoberstar.reckon'
-	}
 }
 
 plugins {
-	id 'org.ajoberstar.reckon' version '0.9.0'
+	id 'org.ajoberstar.reckon' version '0.12.0'
 	id 'net.ltgt.apt-idea' version '0.21'
 	id 'com.github.ben-manes.versions' version '0.27.0' // task: dependencyUpdates
 	id 'org.sonarqube' version '2.8'
+	id 'org.asciidoctor.jvm.convert' version '2.4.0' apply false
+	id 'com.jfrog.bintray' version '1.8.4' apply false
 }
 
 reckon {

--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,7 @@ task jacocoRootReport(type: JacocoReport, group: 'verification') {
 	sourceDirectories.from(subprojects.sourceSets.main.allSource.srcDirs)
 	classDirectories.from(subprojects.sourceSets.main.output)
 	executionData jacocoMerge.destinationFile
+	reports.xml.enabled true
 	doLast {
 		logger.lifecycle("report at: " + reports.html.entryPoint.toURI())
 	}
@@ -135,7 +136,7 @@ allprojects {
 			property 'sonar.host.url', 'https://sonarcloud.io'
 			property 'sonar.organization', 'keykey7-github'
 			property 'sonar.login', System.getenv('SONAR_TOKEN')
-			property 'sonar.jacoco.reportPaths', jacocoMerge.destinationFile
+			property 'sonar.coverage.jacoco.xmlReportPaths', jacocoRootReport.reports.xml.destination
 		}
 	}
 }

--- a/confij-core/build.gradle
+++ b/confij-core/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-	api 'com.fasterxml:classmate:1.4.0'
+	api 'com.fasterxml:classmate:1.5.1'
 }

--- a/confij-documentation/build.gradle
+++ b/confij-documentation/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'base'
-apply plugin: 'org.asciidoctor.convert'
+apply plugin: 'org.asciidoctor.jvm.convert'
 
 dependencies {
 	testImplementation project(':confij-yaml')
@@ -13,25 +13,13 @@ asciidoctor {
 			'group': project.group,
 			'reproducible': 'true',
 			'attribute-missing': 'warn'
-	sources {
-		include 'index.adoc'
-	}
 
-	// workound for https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/154
-	ext.capturedOutput = [ ]
-	def listener = { ext.capturedOutput << it } as StandardOutputListener
-	doFirst {
-		logging.addStandardErrorListener(listener)
-		logging.addStandardOutputListener(listener)
-	}
-	doLast {
-		logging.removeStandardOutputListener(listener)
-		logging.removeStandardErrorListener(listener)
-		ext.capturedOutput.join('').with { output ->
-			if (output =~ /WARNING:|SEVERE:/ && !output.contains('illegal-access=warn')) {
-				throw new GradleException("Warnings found in ${name}:\n" + output)
-			}
+	asciidoctorj {
+		baseDirFollowsSourceDir()
+		sources {
+			include 'index.adoc'
 		}
+		fatalWarnings missingIncludes()
 	}
 }
 

--- a/confij-example/src/test/java/ch/kk7/confij/pipeline/ConfijBuilderTest.java
+++ b/confij-example/src/test/java/ch/kk7/confij/pipeline/ConfijBuilderTest.java
@@ -4,9 +4,7 @@ import ch.kk7.confij.ConfijBuilder;
 import ch.kk7.confij.source.ConfijSourceException;
 import org.assertj.core.api.AbstractStringAssert;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
-import org.junitpioneer.jupiter.TempDirectory.TempDir;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -55,7 +53,6 @@ class ConfijBuilderTest {
 	}
 
 	@Test
-	@ExtendWith(TempDirectory.class)
 	public void fromFile(@TempDir Path tempDir) throws IOException {
 		Path configFile = tempDir.resolve("FileConfig.yml");
 		Files.copy(ClassLoader.getSystemResourceAsStream("MyConfig.yaml"), configFile);

--- a/confij-git/build.gradle
+++ b/confij-git/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
 	api project(':confij-core')
-	implementation 'org.eclipse.jgit:org.eclipse.jgit:5.2.1.201812262042-r'
+	api "org.eclipse.jgit:org.eclipse.jgit:5.6.0.201912101111-r"
 
-	testImplementation("junit:junit:4.12") {
+	testImplementation("junit:junit:4.13") {
 		because 'jgit.junit depends on JUnit4'
 	}
-	testImplementation 'org.eclipse.jgit:org.eclipse.jgit.junit.http:5.2.1.201812262042-r'
-	testImplementation 'org.eclipse.jgit:org.eclipse.jgit.junit.ssh:5.2.1.201812262042-r'
+	testImplementation "org.eclipse.jgit:org.eclipse.jgit.junit.http:5.5.1.201910021850-r"
+	testImplementation "org.eclipse.jgit:org.eclipse.jgit.junit.ssh:5.5.1.201910021850-r"
 }

--- a/confij-hocon/build.gradle
+++ b/confij-hocon/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
 	api project(':confij-core')
-	implementation 'com.typesafe:config:1.3.3'
+	implementation 'com.typesafe:config:1.4.0'
 }

--- a/confij-slf4j/build.gradle
+++ b/confij-slf4j/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
 	api project(':confij-core')
-	api 'org.slf4j:slf4j-api:1.7.25'
+	api 'org.slf4j:slf4j-api:1.7.30'
 
 	testImplementation 'com.github.valfirst:slf4j-test:2.1.1'
 }

--- a/confij-validation/build.gradle
+++ b/confij-validation/build.gradle
@@ -1,8 +1,4 @@
 dependencies {
 	api project(':confij-core')
-
-	api 'org.hibernate.validator:hibernate-validator:6.1.+'
-	// transitive of hibernate-validator since snapshot doesn't declare 'em (fasterxml is already on core classpath)
-	api 'javax.validation:validation-api:2.0.1.Final'
-	implementation 'org.jboss.logging:jboss-logging:3.3.2.Final'
+	api 'org.hibernate.validator:hibernate-validator:6.1.0.Final'
 }

--- a/confij-yaml/build.gradle
+++ b/confij-yaml/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
 	api project(':confij-core')
-	api 'org.yaml:snakeyaml:1.23'
+	api 'org.yaml:snakeyaml:1.25'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-rc-3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- gradle 6.0.1
- hibernate-validator 6.1 final, not relying on snapshots
- jgit is now an api dependency of confij-git
- all other dependency upgrades are considered minor
- dropped gradle build-scan support
- tavis to use opendjk (and not using 9 any more)