### PR TITLE
allow default methods with arguments

### DIFF
--- a/confij-core/src/main/java/ch/kk7/confij/binding/intf/DefaultMethodHandler.java
+++ b/confij-core/src/main/java/ch/kk7/confij/binding/intf/DefaultMethodHandler.java
@@ -46,7 +46,8 @@ public class DefaultMethodHandler {
 		Class<?> forClass = method.getDeclaringClass();
 		try {
 			Lookup lookup = (Lookup) privateLookupIn.invoke(null, forClass, MethodHandles.lookup());
-			return lookup.findSpecial(forClass, method.getName(), MethodType.methodType(method.getReturnType(), new Class[0]), forClass)
+			MethodType methodType = MethodType.methodType(method.getReturnType(), method.getParameterTypes());
+			return lookup.findSpecial(forClass, method.getName(), methodType, forClass)
 					.bindTo(proxy)
 					.invokeWithArguments(args);
 		} catch (Throwable throwable) {

--- a/confij-core/src/test/java/ch/kk7/confij/binding/intf/DefaultsTest.java
+++ b/confij-core/src/test/java/ch/kk7/confij/binding/intf/DefaultsTest.java
@@ -3,6 +3,8 @@ package ch.kk7.confij.binding.intf;
 import ch.kk7.confij.binding.intf.DefaultsTest.WithDefaults;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.UUID;
 
 public class DefaultsTest extends AbstractProxyBuilderTest<WithDefaults> {
@@ -36,6 +38,10 @@ public class DefaultsTest extends AbstractProxyBuilderTest<WithDefaults> {
 
 		default String aCheckedException() throws TestException {
 			throw new TestException();
+		}
+
+		default Path echoPath(Path input) {
+			return input;
 		}
 	}
 
@@ -101,6 +107,13 @@ public class DefaultsTest extends AbstractProxyBuilderTest<WithDefaults> {
 	public void aRandom() {
 		WithDefaults withDefaults = instance();
 		assertThat(withDefaults.aRandomDouble()).isNotEqualTo(withDefaults.aRandomDouble());
+	}
+
+	@Test
+	public void aPath() {
+		WithDefaults withDefaults = instance();
+		Path path = Paths.get("fuu");
+		assertThat(withDefaults.echoPath(path)).isEqualTo(path);
 	}
 
 	@Test

--- a/confij-documentation/src/docs/asciidoc/index.adoc
+++ b/confij-documentation/src/docs/asciidoc/index.adoc
@@ -1,4 +1,4 @@
-= ConfiJ {revnumber} - Reference Guide
+= ConfiJ Reference Guide
 :doctype: book
 :icons: font
 :sectanchors:


### PR DESCRIPTION
Only affects Java >8.
Previously only default methods without arguments were possible (they can be configured after all).
Now also default methods with arguments are allowed.