### PR TITLE
allow serialization of interface proxies

### DIFF
--- a/confij-core/src/main/java/ch/kk7/confij/binding/intf/IntfaceInvocationHandler.java
+++ b/confij-core/src/main/java/ch/kk7/confij/binding/intf/IntfaceInvocationHandler.java
@@ -6,17 +6,27 @@ import ch.kk7.confij.binding.intf.InterfaceProxyBuilder.ConfijHandled;
 import lombok.AllArgsConstructor;
 import lombok.ToString;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 @SuppressWarnings("ProhibitedExceptionDeclared,squid:S00112")
 @AllArgsConstructor
 @ToString
-public class IntfaceInvocationHandler implements InvocationHandler {
-	private final String className;
-	private final Map<Method, Object> methodToValues;
+public class IntfaceInvocationHandler implements InvocationHandler, Serializable {
+	private String className;
+
+	@SuppressWarnings("java:S1948") // serialization is possible IF all values are Serializable
+	private Map<Method, Object> methodToValues;
 
 	@Override
 	public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
@@ -63,14 +73,14 @@ public class IntfaceInvocationHandler implements InvocationHandler {
 	}
 
 	protected String intfToString() {
-		StringBuilder sb = new StringBuilder(className).append("{");
-		methodToValues.forEach((k, v) -> sb.append(k.getName())
-				.append("=")
-				.append(v)
-				.append(", "));
-		sb.setLength(sb.length() - 2);
-		sb.append("}");
-		return sb.toString();
+		return className +
+				"{" +
+				methodToValues.entrySet()
+						.stream()
+						.map(e -> e.getKey()
+								.getName() + "=" + e.getValue())
+						.collect(Collectors.joining(", ")) +
+				"}";
 	}
 
 	protected boolean intfEquals(Object proxy, Object o) {
@@ -82,5 +92,42 @@ public class IntfaceInvocationHandler implements InvocationHandler {
 		}
 		ConfijHandled that = (ConfijHandled) o;
 		return Objects.equals(methodToValues, that.methodToValue());
+	}
+
+	private void writeObject(ObjectOutputStream out) throws IOException {
+		out.writeObject(className);
+		out.writeInt(methodToValues.size());
+		for (Entry<Method, Object> entry : methodToValues.entrySet()) {
+			writeMethodObject(entry.getKey(), out);
+			out.writeObject(entry.getValue());
+		}
+	}
+
+	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+		className = (String) in.readObject();
+		int size = in.readInt();
+		methodToValues = new TreeMap<>(InterfaceProxyBuilder.methodNameComparator);
+		for (int i = 0; i < size; i++) {
+			Method method = readMethodObject(in);
+			Object value = in.readObject();
+			methodToValues.put(method, value);
+		}
+	}
+
+	private static void writeMethodObject(Method method, ObjectOutputStream out) throws IOException {
+		out.writeObject(method.getDeclaringClass());
+		out.writeObject(method.getName());
+		out.writeObject(method.getParameterTypes());
+	}
+
+	private static Method readMethodObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+		Class<?> clazz = (Class<?>) in.readObject();
+		String name = (String) in.readObject();
+		Class<?>[] parameterTypes = (Class<?>[]) in.readObject();
+		try {
+			return clazz.getMethod(name, parameterTypes);
+		} catch (NoSuchMethodException e) {
+			throw new IOException("failed to deserialize method " + clazz + "#" + name + "(" + Arrays.asList(parameterTypes) + ")");
+		}
 	}
 }

--- a/confij-documentation/src/docs/asciidoc/binding.adoc
+++ b/confij-documentation/src/docs/asciidoc/binding.adoc
@@ -156,4 +156,6 @@ If the standard `Collection` interfaces are used ConfiJ will use an immutable re
 But any instance can be used as long as it has an empty constructor (but at the loss of immutability).
 Same holds for `Map<String,?>` types.
 
-WARNING: Java Bean types are not supported yet. Please contribute.
+Interface proxies are Java-serializable if all the customized values are serializable, too.
+
+WARNING: Java Bean types (POJO) are not supported yet. Please contribute.


### PR DESCRIPTION
InterfaceInvocationHandler is now Serializable. It allows simple
serialization IF all the customized configuration values are
serializable, too. Otherwise it will fail lazily while serializing.
Minor: fixed the InterfaceInvocationHandler.toString representation
for empty configurations.

fixes #27