### PR TITLE
Non-Null Validator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,7 @@ subprojects {
 
 	publishing {
 		publications {
-			mavenJava(MavenPublication) {
+			java(MavenPublication) {
 				from components.java
 				pom {
 					name = project.name

--- a/build.gradle
+++ b/build.gradle
@@ -7,11 +7,11 @@ buildscript {
 
 plugins {
 	id 'org.ajoberstar.reckon' version '0.12.0'
-	id 'com.github.ben-manes.versions' version '0.28.0' // task: dependencyUpdates
+	id 'com.github.ben-manes.versions' version '0.29.0' // task: dependencyUpdates
 	id 'org.sonarqube' version '2.8'
-	id 'org.asciidoctor.jvm.convert' version '2.4.0' apply false
+	id 'org.asciidoctor.jvm.convert' version '3.2.0' apply false
 	id 'com.jfrog.bintray' version '1.8.5' apply false
-	id 'com.github.johnrengelman.shadow' version '5.2.0' apply false
+	id 'com.github.johnrengelman.shadow' version '6.0.0' apply false
 }
 
 reckon {

--- a/confij-core/build.gradle
+++ b/confij-core/build.gradle
@@ -32,7 +32,7 @@ artifacts {
 project.afterEvaluate {
 	publishing {
 		publications {
-			mavenJava {
+			shadow(MavenPublication) {
 				artifact shadowJar
 			}
 		}

--- a/confij-core/src/main/java/ch/kk7/confij/ConfijBuilder.java
+++ b/confij-core/src/main/java/ch/kk7/confij/ConfijBuilder.java
@@ -16,8 +16,8 @@ import ch.kk7.confij.source.any.AnySource;
 import ch.kk7.confij.source.defaults.DefaultSource;
 import ch.kk7.confij.source.logical.MaybeSource;
 import ch.kk7.confij.source.logical.OrSource;
-import ch.kk7.confij.template.NoopResolver;
-import ch.kk7.confij.template.VariableResolver;
+import ch.kk7.confij.template.NoopValueResolver;
+import ch.kk7.confij.template.ValueResolver;
 import ch.kk7.confij.tree.NodeBindingContext;
 import ch.kk7.confij.tree.NodeDefinition;
 import ch.kk7.confij.validation.ConfijValidator;
@@ -162,15 +162,16 @@ public class ConfijBuilder<T> {
 		return this;
 	}
 
-	public ConfijBuilder<T> templatingWith(@NonNull VariableResolver variableResolver) {
-		nodeBindingContext = getNodeBindingContext().withVariableResolver(variableResolver);
+	public ConfijBuilder<T> templatingWith(@NonNull ValueResolver valueResolver) {
+		nodeBindingContext = getNodeBindingContext().withValueResolver(valueResolver);
 		return this;
 	}
 
 	public ConfijBuilder<T> templatingDisabled() {
-		return templatingWith(new NoopResolver());
+		return templatingWith(new NoopValueResolver());
 	}
 
+	@Deprecated
 	public ConfijBuilder<T> globalDefaultValue(String defaultValue) {
 		nodeBindingContext = getNodeBindingContext().withDefaultValue(defaultValue);
 		return this;

--- a/confij-core/src/main/java/ch/kk7/confij/ConfijBuilder.java
+++ b/confij-core/src/main/java/ch/kk7/confij/ConfijBuilder.java
@@ -21,6 +21,7 @@ import ch.kk7.confij.template.ValueResolver;
 import ch.kk7.confij.tree.NodeBindingContext;
 import ch.kk7.confij.tree.NodeDefinition;
 import ch.kk7.confij.validation.ConfijValidator;
+import ch.kk7.confij.validation.NonNullValidator;
 import ch.kk7.confij.validation.ServiceLoaderValidator;
 import com.fasterxml.classmate.ResolvedType;
 import lombok.NonNull;
@@ -140,6 +141,10 @@ public class ConfijBuilder<T> {
 	public ConfijBuilder<T> validateWith(@NonNull ConfijValidator validator) {
 		this.validator = validator;
 		return this;
+	}
+
+	public ConfijBuilder<T> validateNonNull() {
+		return validateWith(new NonNullValidator());
 	}
 
 	public ConfijBuilder<T> validationDisabled() {

--- a/confij-core/src/main/java/ch/kk7/confij/ConfijBuilder.java
+++ b/confij-core/src/main/java/ch/kk7/confij/ConfijBuilder.java
@@ -21,6 +21,7 @@ import ch.kk7.confij.template.ValueResolver;
 import ch.kk7.confij.tree.NodeBindingContext;
 import ch.kk7.confij.tree.NodeDefinition;
 import ch.kk7.confij.validation.ConfijValidator;
+import ch.kk7.confij.validation.MultiValidator;
 import ch.kk7.confij.validation.NonNullValidator;
 import ch.kk7.confij.validation.ServiceLoaderValidator;
 import com.fasterxml.classmate.ResolvedType;
@@ -38,6 +39,7 @@ public class ConfijBuilder<T> {
 	private final Type forType;
 	private final List<ConfijSource> sources = new ArrayList<>();
 	private ConfijValidator validator = null;
+	private boolean validateNotNull = false;
 	private NodeBindingContext nodeBindingContext = null;
 	private BindingContext bindingContext = null;
 	private ConfijReloader<T> reloader = null;
@@ -144,7 +146,8 @@ public class ConfijBuilder<T> {
 	}
 
 	public ConfijBuilder<T> validateNonNull() {
-		return validateWith(new NonNullValidator());
+		validateNotNull = true;
+		return this;
 	}
 
 	public ConfijBuilder<T> validationDisabled() {
@@ -214,7 +217,7 @@ public class ConfijBuilder<T> {
 
 	protected ConfijPipeline<T> buildPipeline() {
 		validator = Optional.ofNullable(validator)
-				.orElseGet(ServiceLoaderValidator::new);
+				.orElseGet(() -> MultiValidator.of(new ServiceLoaderValidator(), new NonNullValidator(!validateNotNull)));
 		ConfigBinder configBinder = new ConfigBinder();
 		@SuppressWarnings("unchecked")
 		ConfigBinding<T> configBinding = (ConfigBinding<T>) configBinder.toRootConfigBinding(forType, getBindingContext());

--- a/confij-core/src/main/java/ch/kk7/confij/annotation/Default.java
+++ b/confij-core/src/main/java/ch/kk7/confij/annotation/Default.java
@@ -5,8 +5,25 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Defines the default value for a configuration item (leaf).
+ * Default values are loaded first and can be overridden by any other configuration source
+ * (so they have lowest preference).
+ * <pre>
+ * interface Fuu {
+ *     \@Default("42") int theAnswer();
+ * }
+ * </pre>
+ *
+ * @see ch.kk7.confij.source.defaults.DefaultSource
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Default {
 	String value();
+
+	/**
+	 * @return true if the {@link #value()} is actually null
+	 */
+	boolean isNull() default false;
 }

--- a/confij-core/src/main/java/ch/kk7/confij/annotation/Key.java
+++ b/confij-core/src/main/java/ch/kk7/confij/annotation/Key.java
@@ -5,6 +5,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Overrides to which key in the configuration(-file) this value should be mapped.
+ * The default key is always the method name:
+ * <pre>
+ * interface Fuu {
+ *     \@Key("actualKey") String thisMethodNameIsIgnored();
+ * }
+ * </pre>
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Key {

--- a/confij-core/src/main/java/ch/kk7/confij/annotation/VariableResolver.java
+++ b/confij-core/src/main/java/ch/kk7/confij/annotation/VariableResolver.java
@@ -1,5 +1,7 @@
 package ch.kk7.confij.annotation;
 
+import ch.kk7.confij.template.ValueResolver;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -10,5 +12,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 public @interface VariableResolver {
-	Class<? extends ch.kk7.confij.template.VariableResolver> value();
+	Class<? extends ValueResolver> value();
 }

--- a/confij-core/src/main/java/ch/kk7/confij/binding/BindingContext.java
+++ b/confij-core/src/main/java/ch/kk7/confij/binding/BindingContext.java
@@ -5,6 +5,7 @@ import ch.kk7.confij.binding.values.DateTimeMapper;
 import ch.kk7.confij.binding.values.DurationMapper;
 import ch.kk7.confij.binding.values.EnumMapper;
 import ch.kk7.confij.binding.values.ExplicitMapper;
+import ch.kk7.confij.binding.values.OptionalMapper;
 import ch.kk7.confij.binding.values.PeriodMapper;
 import ch.kk7.confij.binding.values.PrimitiveMapperFactory;
 import ch.kk7.confij.binding.values.SoloConstructorMapper;
@@ -16,6 +17,7 @@ import ch.kk7.confij.common.ClassToImplCache;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.ToString;
 import lombok.Value;
 import lombok.With;
 import lombok.experimental.NonFinal;
@@ -38,15 +40,16 @@ import java.util.Optional;
 @With
 @NonFinal
 public class BindingContext {
-	private final ValueMapperFactory forcedMapperFactory;
+	ValueMapperFactory forcedMapperFactory;
 	@Getter
 	@NonNull
-	private final List<ValueMapperFactory> mapperFactories;
+	List<ValueMapperFactory> mapperFactories;
 	@NonNull
-	private final Map<Class<? extends ValueMapperFactory>, Annotation> factoryConfigs;
+	Map<Class<? extends ValueMapperFactory>, Annotation> factoryConfigs;
 	@NonNull
+	@ToString.Exclude
 	@With(AccessLevel.NONE)
-	private final ClassToImplCache implCache;
+	ClassToImplCache implCache;
 
 	public BindingContext(ValueMapperFactory forcedMapperFactory, @NonNull List<ValueMapperFactory> mapperFactories,
 			@NonNull Map<Class<? extends ValueMapperFactory>, Annotation> factoryConfigs, @NonNull ClassToImplCache implCache) {
@@ -58,8 +61,8 @@ public class BindingContext {
 
 	public static BindingContext newDefaultContext() {
 		List<ValueMapperFactory> mapperFactories = Arrays.asList(ExplicitMapper.forString(), new PrimitiveMapperFactory(),
-				ExplicitMapper.forFile(), ExplicitMapper.forPath(), new EnumMapper(), new DurationMapper(), new PeriodMapper(),
-				new DateTimeMapper(), new StaticFunctionMapper(), new SoloConstructorMapper());
+				new OptionalMapper(), ExplicitMapper.forFile(), ExplicitMapper.forPath(), new EnumMapper(), new DurationMapper(),
+				new PeriodMapper(), new DateTimeMapper(), new StaticFunctionMapper(), new SoloConstructorMapper());
 		return new BindingContext(null, mapperFactories, Collections.emptyMap(), new ClassToImplCache());
 	}
 

--- a/confij-core/src/main/java/ch/kk7/confij/binding/BindingResult.java
+++ b/confij-core/src/main/java/ch/kk7/confij/binding/BindingResult.java
@@ -1,0 +1,34 @@
+package ch.kk7.confij.binding;
+
+import ch.kk7.confij.tree.ConfijNode;
+import lombok.NonNull;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The outcome when buiding the final configuration object, but still keep it linked
+ * to the old {@link ConfijNode} and its child-results. Facilitates post-processing,
+ * such as with a {@link ch.kk7.confij.validation.ConfijValidator}.
+ *
+ * @param <T>
+ */
+@NonFinal
+@Value
+public class BindingResult<T> {
+	T value;
+
+	@NonNull ConfijNode node;
+
+	@NonNull List<BindingResult<?>> children;
+
+	public static <X> BindingResult<X> ofLeaf(X value, ConfijNode node) {
+		return of(value, node, Collections.emptyList());
+	}
+
+	public static <X> BindingResult<X> of(X value, ConfijNode node, List<BindingResult<?>> children) {
+		return new BindingResult<>(value, node, Collections.unmodifiableList(children));
+	}
+}

--- a/confij-core/src/main/java/ch/kk7/confij/binding/ConfigBinder.java
+++ b/confij-core/src/main/java/ch/kk7/confij/binding/ConfigBinder.java
@@ -31,6 +31,7 @@ public class ConfigBinder {
 		bindingFactories.add(new ArrayBindingFactory());
 		bindingFactories.add(new CollectionBindingFactory());
 		bindingFactories.add(new MapBindingFactory());
+		// interface binding last (since everything before is an interface, too)
 		bindingFactories.add(new InterfaceBindingFactory());
 	}
 

--- a/confij-core/src/main/java/ch/kk7/confij/binding/ConfigBinding.java
+++ b/confij-core/src/main/java/ch/kk7/confij/binding/ConfigBinding.java
@@ -13,5 +13,5 @@ import ch.kk7.confij.tree.ConfijNode;
 public interface ConfigBinding<T> {
 	NodeDefinition describe(NodeBindingContext nodeBindingContext);
 
-	T bind(ConfijNode config);
+	BindingResult<T> bind(ConfijNode config);
 }

--- a/confij-core/src/main/java/ch/kk7/confij/binding/array/ArrayBinding.java
+++ b/confij-core/src/main/java/ch/kk7/confij/binding/array/ArrayBinding.java
@@ -1,5 +1,6 @@
 package ch.kk7.confij.binding.array;
 
+import ch.kk7.confij.binding.BindingResult;
 import ch.kk7.confij.binding.BindingType;
 import ch.kk7.confij.binding.ConfigBinder;
 import ch.kk7.confij.binding.ConfigBinding;
@@ -11,6 +12,7 @@ import com.fasterxml.classmate.ResolvedType;
 import lombok.ToString;
 
 import java.lang.reflect.Array;
+import java.util.ArrayList;
 import java.util.List;
 
 @ToString
@@ -33,14 +35,17 @@ public class ArrayBinding<T> implements ConfigBinding<Object> {
 	 * binds to Object instead of T[] since it also handles primitive arrays
 	 */
 	@Override
-	public Object bind(ConfijNode config) {
+	public BindingResult<Object> bind(ConfijNode config) {
+		List<BindingResult<?>> bindingResultChildren = new ArrayList<>();
 		// TODO: add config to allow null values in array
 		List<ConfijNode> childNodes = CollectionUtil.childrenAsContinuousList(config);
 		Object result = Array.newInstance(componentType.getErasedType(), childNodes.size());
 		int i = 0;
 		for (ConfijNode childNode : childNodes) {
-			Array.set(result, i++, componentDescription.bind(childNode));
+			BindingResult<?> item = componentDescription.bind(childNode);
+			Array.set(result, i++, item.getValue());
+			bindingResultChildren.add(item);
 		}
-		return result;
+		return BindingResult.of(result, config, bindingResultChildren);
 	}
 }

--- a/confij-core/src/main/java/ch/kk7/confij/binding/collection/CollectionBinding.java
+++ b/confij-core/src/main/java/ch/kk7/confij/binding/collection/CollectionBinding.java
@@ -1,12 +1,14 @@
 package ch.kk7.confij.binding.collection;
 
+import ch.kk7.confij.binding.BindingResult;
 import ch.kk7.confij.binding.BindingType;
 import ch.kk7.confij.binding.ConfigBinder;
 import ch.kk7.confij.binding.ConfigBinding;
-import ch.kk7.confij.tree.NodeDefinition.NodeDefinitionList;
-import ch.kk7.confij.tree.NodeBindingContext;
 import ch.kk7.confij.tree.ConfijNode;
+import ch.kk7.confij.tree.NodeBindingContext;
+import ch.kk7.confij.tree.NodeDefinition.NodeDefinitionList;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -26,15 +28,16 @@ public class CollectionBinding<T> implements ConfigBinding<Collection<T>> {
 	}
 
 	@Override
-	public Collection<T> bind(ConfijNode config) {
-		// we use a map here to allow for sparse array implementations
-		// TODO: add config to enforce continuous indexes
+	public BindingResult<Collection<T>> bind(ConfijNode config) {
+		List<BindingResult<?>> bindingResultChildren = new ArrayList<>();
+		// TODO: add config to enforce continuous indexes as we currently allow sparse collection types
 		List<ConfijNode> childNodes = CollectionUtil.childrenAsContinuousList(config);
 		Collection<T> collection = builder.newInstance();
 		for (ConfijNode childNode : childNodes) {
-			T listItem = componentDescription.bind(childNode);
-			collection.add(listItem);
+			BindingResult<T> listItem = componentDescription.bind(childNode);
+			collection.add(listItem.getValue());
+			bindingResultChildren.add(listItem);
 		}
-		return builder.tryHarden(collection);
+		return BindingResult.of(builder.tryHarden(collection), config, bindingResultChildren);
 	}
 }

--- a/confij-core/src/main/java/ch/kk7/confij/binding/intf/InterfaceProxyBuilder.java
+++ b/confij-core/src/main/java/ch/kk7/confij/binding/intf/InterfaceProxyBuilder.java
@@ -31,7 +31,7 @@ import static java.util.stream.Collectors.toMap;
 public class InterfaceProxyBuilder<T> {
 	private static final Map<Class<?>, Object> PRIMITIVE_ZEROS = Stream.of(boolean.class, byte.class, char.class, double.class, float.class,
 			int.class, long.class, short.class)
-			.collect(toMap(clazz -> (Class<?>) clazz, clazz -> Array.get(Array.newInstance(clazz, 1), 0)));
+			.collect(toMap(clazz -> clazz, clazz -> Array.get(Array.newInstance(clazz, 1), 0)));
 
 	/**
 	 * make comparator serializable to allow serialization of this TreeMap and thus the Proxy

--- a/confij-core/src/main/java/ch/kk7/confij/binding/leaf/LeafBinding.java
+++ b/confij-core/src/main/java/ch/kk7/confij/binding/leaf/LeafBinding.java
@@ -1,5 +1,6 @@
 package ch.kk7.confij.binding.leaf;
 
+import ch.kk7.confij.binding.BindingResult;
 import ch.kk7.confij.binding.ConfigBinding;
 import ch.kk7.confij.binding.values.ValueMapperInstance;
 import ch.kk7.confij.tree.NodeDefinition.NodeDefinitionLeaf;
@@ -21,11 +22,11 @@ public class LeafBinding<T> implements ConfigBinding<T> {
 	}
 
 	@Override
-	public T bind(ConfijNode leaf) {
-		String value = leaf.getConfig()
+	public BindingResult<T> bind(ConfijNode leafNode) {
+		String strValue = leafNode.getConfig()
 				.getNodeBindingContext()
 				.getValueResolver()
-				.resolveLeaf(leaf);
-		return valueMapper.fromString(value);
+				.resolveLeaf(leafNode);
+		return BindingResult.ofLeaf(valueMapper.fromString(strValue), leafNode);
 	}
 }

--- a/confij-core/src/main/java/ch/kk7/confij/binding/leaf/LeafBinding.java
+++ b/confij-core/src/main/java/ch/kk7/confij/binding/leaf/LeafBinding.java
@@ -24,7 +24,7 @@ public class LeafBinding<T> implements ConfigBinding<T> {
 	public T bind(ConfijNode leaf) {
 		String value = leaf.getConfig()
 				.getNodeBindingContext()
-				.getVariableResolver()
+				.getValueResolver()
 				.resolveLeaf(leaf);
 		return valueMapper.fromString(value);
 	}

--- a/confij-core/src/main/java/ch/kk7/confij/binding/leaf/LeafBindingFactory.java
+++ b/confij-core/src/main/java/ch/kk7/confij/binding/leaf/LeafBindingFactory.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 
 @ToString
 public class LeafBindingFactory implements ConfigBindingFactory<LeafBinding> {
+
+	// TODO: drop this static method and use the current non-static LeafBindingFactory instead
 	public static Optional<ValueMapperInstance> firstValueMapper(BindingType bindingType) {
 		return bindingType.getBindingContext()
 				.getMapperFactories()

--- a/confij-core/src/main/java/ch/kk7/confij/binding/values/OptionalMapper.java
+++ b/confij-core/src/main/java/ch/kk7/confij/binding/values/OptionalMapper.java
@@ -1,0 +1,45 @@
+package ch.kk7.confij.binding.values;
+
+import ch.kk7.confij.binding.BindingType;
+import ch.kk7.confij.binding.ConfijBindingException;
+import ch.kk7.confij.binding.leaf.LeafBindingFactory;
+import com.fasterxml.classmate.ResolvedType;
+import lombok.Value;
+
+import java.util.Optional;
+
+@SuppressWarnings("rawtypes")
+public class OptionalMapper extends AbstractClassValueMapper<Optional> {
+	public OptionalMapper() {
+		super(Optional.class);
+	}
+
+	@Override
+	public OptionalMapperInstance newInstance(BindingType bindingType) {
+		ResolvedType innerResolvedType = bindingType.getResolvedType()
+				.typeParametersFor(Optional.class)
+				.get(0);
+		BindingType innerBindingType = bindingType.bindingFor(innerResolvedType);
+		Optional<ValueMapperInstance> innerMapper = LeafBindingFactory.firstValueMapper(innerBindingType);
+		if (!innerMapper.isPresent()) {
+			throw new ConfijBindingException(
+					"cannot bind to type {}: {} only supports known leaf-types (direct values). This parameter isn't supported.",
+					bindingType.getResolvedType(), this);
+		} else {
+			return new OptionalMapperInstance(innerMapper.get());
+		}
+	}
+
+	@Value
+	public static class OptionalMapperInstance<T> implements ValueMapperInstance<Optional<T>> {
+		ValueMapperInstance<T> componentMapper;
+
+		@Override
+		public Optional<T> fromString(String string) {
+			if (string == null) {
+				return Optional.empty();
+			}
+			return Optional.of(componentMapper.fromString(string));
+		}
+	}
+}

--- a/confij-core/src/main/java/ch/kk7/confij/common/AnnotationUtil.java
+++ b/confij-core/src/main/java/ch/kk7/confij/common/AnnotationUtil.java
@@ -17,12 +17,12 @@ import java.util.Set;
 public class AnnotationUtil {
 
 	@Value
-	public static class AnnonResponse<A extends Annotation> {
+	public class AnnonResponse<A extends Annotation> {
 		Annotation declaredAnnotation;
 		A annotationType;
 	}
 
-	public static <A extends Annotation> Optional<AnnonResponse<A>>
+	public <A extends Annotation> Optional<AnnonResponse<A>>
 			findAnnotationAndDeclaration(AnnotatedElement annotatedElement, Class<A> annotationType) {
 		A annotation = annotatedElement.getDeclaredAnnotation(annotationType);
 		if (annotation != null) {
@@ -41,12 +41,16 @@ public class AnnotationUtil {
 		return Optional.empty();
 	}
 
-	public static <A extends Annotation> Optional<A> findAnnotation(AnnotatedElement annotatedElement, Class<A> annotationType) {
+	/**
+	 * Find a single Annotation of annotationType on the supplied AnnotatedElement.
+	 * Meta-annotations will be searched if the annotation is not directly present on the supplied element.
+	 */
+	public <A extends Annotation> Optional<A> findAnnotation(AnnotatedElement annotatedElement, Class<A> annotationType) {
 		// TODO: cache the result
 		return Optional.ofNullable(findAnnotation(annotatedElement, annotationType, new HashSet<>()));
 	}
 
-	private static <A extends Annotation> A findAnnotation(AnnotatedElement annotatedElement, Class<A> annotationType,
+	private <A extends Annotation> A findAnnotation(AnnotatedElement annotatedElement, Class<A> annotationType,
 			Set<Annotation> visited) {
 		A annotation = annotatedElement.getDeclaredAnnotation(annotationType);
 		if (annotation != null) {
@@ -64,11 +68,11 @@ public class AnnotationUtil {
 		return null;
 	}
 
-	static boolean isInJavaLangAnnotationPackage(Class<? extends Annotation> annotationType) {
+	boolean isInJavaLangAnnotationPackage(Class<? extends Annotation> annotationType) {
 		return (annotationType != null && isInJavaLangAnnotationPackage(annotationType.getName()));
 	}
 
-	public static boolean isInJavaLangAnnotationPackage(String annotationType) {
+	public boolean isInJavaLangAnnotationPackage(String annotationType) {
 		return (annotationType != null && annotationType.startsWith("java.lang.annotation"));
 	}
 }

--- a/confij-core/src/main/java/ch/kk7/confij/common/AnnotationUtil.java
+++ b/confij-core/src/main/java/ch/kk7/confij/common/AnnotationUtil.java
@@ -17,7 +17,7 @@ import java.util.Set;
 public class AnnotationUtil {
 
 	@Value
-	public class AnnonResponse<A extends Annotation> {
+	public static class AnnonResponse<A extends Annotation> {
 		Annotation declaredAnnotation;
 		A annotationType;
 	}

--- a/confij-core/src/main/java/ch/kk7/confij/pipeline/ConfijPipelineImpl.java
+++ b/confij-core/src/main/java/ch/kk7/confij/pipeline/ConfijPipelineImpl.java
@@ -46,7 +46,7 @@ public class ConfijPipelineImpl<T> implements ConfijPipeline<T> {
 	public T build() {
 		ConfijNode simpleConfig = readConfigToNode();
 		T config = bind(simpleConfig);
-		validator.validate(config);
+		validator.validate(config, simpleConfig);
 		return config;
 	}
 }

--- a/confij-core/src/main/java/ch/kk7/confij/pipeline/ConfijPipelineImpl.java
+++ b/confij-core/src/main/java/ch/kk7/confij/pipeline/ConfijPipelineImpl.java
@@ -1,5 +1,6 @@
 package ch.kk7.confij.pipeline;
 
+import ch.kk7.confij.binding.BindingResult;
 import ch.kk7.confij.binding.ConfigBinding;
 import ch.kk7.confij.source.ConfijSource;
 import ch.kk7.confij.tree.ConfijNode;
@@ -38,15 +39,15 @@ public class ConfijPipelineImpl<T> implements ConfijPipeline<T> {
 		return rootNode;
 	}
 
-	protected T bind(ConfijNode rootNode) {
+	protected BindingResult<T> bind(ConfijNode rootNode) {
 		return configBinding.bind(rootNode);
 	}
 
 	@Override
 	public T build() {
 		ConfijNode simpleConfig = readConfigToNode();
-		T config = bind(simpleConfig);
-		validator.validate(config, simpleConfig);
-		return config;
+		BindingResult<T> bindingResult = bind(simpleConfig);
+		validator.validate(bindingResult);
+		return bindingResult.getValue();
 	}
 }

--- a/confij-core/src/main/java/ch/kk7/confij/source/any/AnySource.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/any/AnySource.java
@@ -4,7 +4,7 @@ import ch.kk7.confij.common.ServiceLoaderUtil;
 import ch.kk7.confij.source.ConfijSource;
 import ch.kk7.confij.source.ConfijSourceBuilder;
 import ch.kk7.confij.source.ConfijSourceException;
-import ch.kk7.confij.template.VariableResolver;
+import ch.kk7.confij.template.ValueResolver;
 import ch.kk7.confij.tree.ConfijNode;
 import lombok.Data;
 
@@ -31,10 +31,10 @@ public class AnySource implements ConfijSource {
 		sourceBuilders = ServiceLoaderUtil.requireInstancesOf(ConfijSourceBuilder.class);
 	}
 
-	protected VariableResolver getResolver(ConfijNode rootNode) {
+	protected ValueResolver getResolver(ConfijNode rootNode) {
 		return rootNode.getConfig()
 				.getNodeBindingContext()
-				.getVariableResolver();
+				.getValueResolver();
 	}
 
 	protected URI resolveUri(ConfijNode rootNode) {

--- a/confij-core/src/main/java/ch/kk7/confij/source/defaults/DefaultSource.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/defaults/DefaultSource.java
@@ -8,7 +8,8 @@ import java.util.Set;
 
 /**
  * This is a special ConfigSource since it does not simply override existing values.
- * It rather extends them, by introducing missing nodes and setting default values.
+ * It rather extends them, by introducing missing nodes and setting default values
+ * (all taken from code and not from external).
  */
 public class DefaultSource implements ConfijSource {
 	@Override

--- a/confij-core/src/main/java/ch/kk7/confij/source/env/PropertiesSource.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/env/PropertiesSource.java
@@ -18,6 +18,10 @@ public class PropertiesSource extends PropertiesFormat implements ConfijSource {
 		setSeparator(".");
 	}
 
+	public static PropertiesSource of(String key, String value) {
+		return new PropertiesSource().with(key, value);
+	}
+
 	public PropertiesSource with(String key, String value) {
 		if (value == null) {
 			properties.remove(key);

--- a/confij-core/src/main/java/ch/kk7/confij/template/NoopValueResolver.java
+++ b/confij-core/src/main/java/ch/kk7/confij/template/NoopValueResolver.java
@@ -8,12 +8,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-public class NoopResolver implements VariableResolver {
+public class NoopValueResolver implements ValueResolver {
 	@Inherited
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ElementType.METHOD, ElementType.TYPE})
-	@ch.kk7.confij.annotation.VariableResolver(NoopResolver.class)
-	public @interface NoopVariableResolver {
+	@ch.kk7.confij.annotation.VariableResolver(NoopValueResolver.class)
+	public @interface NoopResolver {
 	}
 
 	@Override

--- a/confij-core/src/main/java/ch/kk7/confij/template/SimpleVariableResolver.java
+++ b/confij-core/src/main/java/ch/kk7/confij/template/SimpleVariableResolver.java
@@ -5,6 +5,11 @@ import ch.kk7.confij.common.ConfijException;
 import ch.kk7.confij.tree.ConfijNode;
 import lombok.ToString;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -17,7 +22,15 @@ import java.util.stream.Collectors;
 
 // TODO: make ThreadSafe
 @ToString
-public class DefaultResolver implements VariableResolver {
+public class SimpleVariableResolver implements ValueResolver {
+
+	@Inherited
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ElementType.METHOD, ElementType.TYPE})
+	@ch.kk7.confij.annotation.VariableResolver(SimpleVariableResolver.class)
+	public @interface SimpleResolver {
+	}
+
 	private char escapeChar = '\\';
 	private String pathSeparator = ".";
 	private final Map<ConfijNode, String> resolvedLeaves = new HashMap<>();

--- a/confij-core/src/main/java/ch/kk7/confij/template/ValueResolver.java
+++ b/confij-core/src/main/java/ch/kk7/confij/template/ValueResolver.java
@@ -3,7 +3,7 @@ package ch.kk7.confij.template;
 import ch.kk7.confij.tree.ConfijNode;
 
 @FunctionalInterface
-public interface VariableResolver {
+public interface ValueResolver {
 	String resolveValue(ConfijNode baseLeaf, String valueToResolve);
 
 	default String resolveLeaf(ConfijNode leaf) {

--- a/confij-core/src/main/java/ch/kk7/confij/tree/ConfijNode.java
+++ b/confij-core/src/main/java/ch/kk7/confij/tree/ConfijNode.java
@@ -24,6 +24,7 @@ public class ConfijNode {
 	private final Map<String, ConfijNode> children = new LinkedHashMap<>();
 	@NonNull
 	private final ConfijNode root;
+	@Getter
 	@NonNull
 	@ToString.Include
 	@EqualsAndHashCode.Include

--- a/confij-core/src/main/java/ch/kk7/confij/tree/ConfijNode.java
+++ b/confij-core/src/main/java/ch/kk7/confij/tree/ConfijNode.java
@@ -14,6 +14,10 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * Builds and navigates the configurations tree structure out of {@link NodeDefinition}s,
+ * indexes each node with a URI and links it to the configured String-value.
+ */
 @ToString(onlyExplicitlyIncluded = true, doNotUseGetters = true)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class ConfijNode {

--- a/confij-core/src/main/java/ch/kk7/confij/tree/NodeDefinition.java
+++ b/confij-core/src/main/java/ch/kk7/confij/tree/NodeDefinition.java
@@ -13,7 +13,7 @@ import java.util.Set;
 
 /**
  * The definition of how the config must look like on a high level, like
- * what children it can and must contain.
+ * what children it can and must contain. No link to actual config values.
  */
 @Value
 @NonFinal

--- a/confij-core/src/main/java/ch/kk7/confij/validation/ConfijValidationException.java
+++ b/confij-core/src/main/java/ch/kk7/confij/validation/ConfijValidationException.java
@@ -1,0 +1,17 @@
+package ch.kk7.confij.validation;
+
+import ch.kk7.confij.common.ConfijException;
+
+public class ConfijValidationException extends ConfijException {
+	public ConfijValidationException(String s) {
+		super(s);
+	}
+
+	public ConfijValidationException(String s, Throwable throwable) {
+		super(s, throwable);
+	}
+
+	public ConfijValidationException(String s, Object... args) {
+		super(s, args);
+	}
+}

--- a/confij-core/src/main/java/ch/kk7/confij/validation/ConfijValidator.java
+++ b/confij-core/src/main/java/ch/kk7/confij/validation/ConfijValidator.java
@@ -1,9 +1,15 @@
 package ch.kk7.confij.validation;
 
+import ch.kk7.confij.tree.ConfijNode;
+
 @FunctionalInterface
 public interface ConfijValidator {
 	ConfijValidator NOOP = config -> {
 	};
+
+	default void validate(Object config, ConfijNode confijNode) {
+		validate(config);
+	}
 
 	void validate(Object config);
 }

--- a/confij-core/src/main/java/ch/kk7/confij/validation/ConfijValidator.java
+++ b/confij-core/src/main/java/ch/kk7/confij/validation/ConfijValidator.java
@@ -1,15 +1,11 @@
 package ch.kk7.confij.validation;
 
-import ch.kk7.confij.tree.ConfijNode;
+import ch.kk7.confij.binding.BindingResult;
 
 @FunctionalInterface
-public interface ConfijValidator {
-	ConfijValidator NOOP = config -> {
+public interface ConfijValidator<T> {
+	ConfijValidator<?> NOOP = config -> {
 	};
 
-	default void validate(Object config, ConfijNode confijNode) {
-		validate(config);
-	}
-
-	void validate(Object config) throws ConfijValidationException;
+	void validate(BindingResult<T> bindingResult) throws ConfijValidationException;
 }

--- a/confij-core/src/main/java/ch/kk7/confij/validation/ConfijValidator.java
+++ b/confij-core/src/main/java/ch/kk7/confij/validation/ConfijValidator.java
@@ -4,8 +4,10 @@ import ch.kk7.confij.binding.BindingResult;
 
 @FunctionalInterface
 public interface ConfijValidator<T> {
-	ConfijValidator<?> NOOP = config -> {
-	};
+	static <T> ConfijValidator<T> noopValidator() {
+		return config -> {
+		};
+	}
 
 	void validate(BindingResult<T> bindingResult) throws ConfijValidationException;
 }

--- a/confij-core/src/main/java/ch/kk7/confij/validation/ConfijValidator.java
+++ b/confij-core/src/main/java/ch/kk7/confij/validation/ConfijValidator.java
@@ -11,5 +11,5 @@ public interface ConfijValidator {
 		validate(config);
 	}
 
-	void validate(Object config);
+	void validate(Object config) throws ConfijValidationException;
 }

--- a/confij-core/src/main/java/ch/kk7/confij/validation/MultiValidator.java
+++ b/confij-core/src/main/java/ch/kk7/confij/validation/MultiValidator.java
@@ -1,0 +1,28 @@
+package ch.kk7.confij.validation;
+
+import ch.kk7.confij.tree.ConfijNode;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Value
+@NonFinal
+public class MultiValidator implements ConfijValidator {
+	List<ConfijValidator> validators;
+
+	public static MultiValidator of(ConfijValidator... validators) {
+		return new MultiValidator(Arrays.asList(validators));
+	}
+
+	@Override
+	public void validate(Object config, ConfijNode confijNode) {
+		validators.forEach(x -> x.validate(config, confijNode));
+	}
+
+	@Override
+	public void validate(Object config) throws ConfijValidationException {
+		validators.forEach(x -> x.validate(config));
+	}
+}

--- a/confij-core/src/main/java/ch/kk7/confij/validation/MultiValidator.java
+++ b/confij-core/src/main/java/ch/kk7/confij/validation/MultiValidator.java
@@ -1,6 +1,6 @@
 package ch.kk7.confij.validation;
 
-import ch.kk7.confij.tree.ConfijNode;
+import ch.kk7.confij.binding.BindingResult;
 import lombok.Value;
 import lombok.experimental.NonFinal;
 
@@ -9,20 +9,16 @@ import java.util.List;
 
 @Value
 @NonFinal
-public class MultiValidator implements ConfijValidator {
-	List<ConfijValidator> validators;
+public class MultiValidator<T> implements ConfijValidator<T> {
+	List<ConfijValidator<T>> validators;
 
-	public static MultiValidator of(ConfijValidator... validators) {
-		return new MultiValidator(Arrays.asList(validators));
+	@SafeVarargs
+	public static <T> MultiValidator<T> of(ConfijValidator<T>... validators) {
+		return new MultiValidator<>(Arrays.asList(validators));
 	}
 
 	@Override
-	public void validate(Object config, ConfijNode confijNode) {
-		validators.forEach(x -> x.validate(config, confijNode));
-	}
-
-	@Override
-	public void validate(Object config) throws ConfijValidationException {
-		validators.forEach(x -> x.validate(config));
+	public void validate(BindingResult<T> bindingResult) {
+		validators.forEach(x -> x.validate(bindingResult));
 	}
 }

--- a/confij-core/src/main/java/ch/kk7/confij/validation/NonNullValidator.java
+++ b/confij-core/src/main/java/ch/kk7/confij/validation/NonNullValidator.java
@@ -43,10 +43,16 @@ public class NonNullValidator<T> implements ConfijValidator<T> {
 	public @interface NotNull {
 	}
 
+	/**
+	 * implicit {@link Nullable} at configuration root
+	 */
 	public static <T> NonNullValidator<T> initiallyNullable() {
 		return new NonNullValidator<>(true);
 	}
 
+	/**
+	 * implicit {@link NotNull} at configuration root
+	 */
 	public static <T> NonNullValidator<T> initiallyNotNull() {
 		return new NonNullValidator<>(false);
 	}

--- a/confij-core/src/main/java/ch/kk7/confij/validation/NonNullValidator.java
+++ b/confij-core/src/main/java/ch/kk7/confij/validation/NonNullValidator.java
@@ -1,0 +1,51 @@
+package ch.kk7.confij.validation;
+
+import ch.kk7.confij.common.ConfijException;
+import ch.kk7.confij.tree.ConfijNode;
+import lombok.Value;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.AnnotatedElement;
+import java.util.Arrays;
+import java.util.Set;
+
+@Value
+public class NonNullValidator implements ConfijValidator{
+	@Inherited
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ElementType.METHOD, ElementType.TYPE})
+	public @interface Nullable {
+	}
+
+	@Override
+	public void validate(Object config) {
+		throw new ConfijException("not to be called without ConfijNode");
+	}
+
+	@Override
+	public void validate(Object config, ConfijNode rootNode) {
+		validateNode(rootNode);
+	}
+
+	protected void validateNode(ConfijNode node) {
+		if (node.getConfig()
+				.isValueHolder()) {
+			node.getConfig().getNodeBindingContext().getAnnotatedElement()
+
+			String value = node.getValue();
+			if (value == null) {
+
+			}
+		}
+	}
+
+	protected final Set<String>
+
+	protected void isNullable(AnnotatedElement element) {
+		Arrays.stream(element.getDeclaredAnnotations()).filter(x -> x.annotationType().getSimpleName().toLowerCase())
+	}
+}

--- a/confij-core/src/main/java/ch/kk7/confij/validation/ServiceLoaderValidator.java
+++ b/confij-core/src/main/java/ch/kk7/confij/validation/ServiceLoaderValidator.java
@@ -1,13 +1,13 @@
 package ch.kk7.confij.validation;
 
-import ch.kk7.confij.tree.ConfijNode;
+import ch.kk7.confij.binding.BindingResult;
 
 import java.util.List;
 
 import static ch.kk7.confij.common.ServiceLoaderUtil.instancesOf;
 
 // NOT detectable by serviceLoader himself
-public class ServiceLoaderValidator implements ConfijValidator {
+public class ServiceLoaderValidator<T> implements ConfijValidator<T> {
 	private final List<ConfijValidator> validators;
 
 	public ServiceLoaderValidator() {
@@ -15,12 +15,7 @@ public class ServiceLoaderValidator implements ConfijValidator {
 	}
 
 	@Override
-	public void validate(Object config, ConfijNode confijNode) {
-		validators.forEach(validator -> validator.validate(config, confijNode));
-	}
-
-	@Override
-	public void validate(Object config) {
-		validators.forEach(validator -> validator.validate(config));
+	public void validate(BindingResult<T> bindingResult) {
+		validators.forEach(validator -> validator.validate(bindingResult));
 	}
 }

--- a/confij-core/src/main/java/ch/kk7/confij/validation/ServiceLoaderValidator.java
+++ b/confij-core/src/main/java/ch/kk7/confij/validation/ServiceLoaderValidator.java
@@ -1,8 +1,10 @@
 package ch.kk7.confij.validation;
 
-import static ch.kk7.confij.common.ServiceLoaderUtil.instancesOf;
+import ch.kk7.confij.tree.ConfijNode;
 
 import java.util.List;
+
+import static ch.kk7.confij.common.ServiceLoaderUtil.instancesOf;
 
 // NOT detectable by serviceLoader himself
 public class ServiceLoaderValidator implements ConfijValidator {
@@ -10,6 +12,11 @@ public class ServiceLoaderValidator implements ConfijValidator {
 
 	public ServiceLoaderValidator() {
 		validators = instancesOf(ConfijValidator.class);
+	}
+
+	@Override
+	public void validate(Object config, ConfijNode confijNode) {
+		validators.forEach(validator -> validator.validate(config, confijNode));
 	}
 
 	@Override

--- a/confij-core/src/test/java/ch/kk7/confij/binding/values/OptionalMapperTest.java
+++ b/confij-core/src/test/java/ch/kk7/confij/binding/values/OptionalMapperTest.java
@@ -1,0 +1,42 @@
+package ch.kk7.confij.binding.values;
+
+import ch.kk7.confij.ConfijBuilder;
+import ch.kk7.confij.annotation.Default;
+import ch.kk7.confij.binding.ConfijBindingException;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+public class OptionalMapperTest implements WithAssertions {
+	interface WithOptional {
+		@Default("str")
+		Optional<String> string();
+
+		@Default("123456")
+		Optional<Long> looong();
+
+		Optional<String> empty();
+
+		WithOptional INSTANCE = ConfijBuilder.of(WithOptional.class)
+				.build();
+	}
+
+	interface Complex {
+		Optional<WithOptional> complex();
+	}
+
+	@Test
+	public void simple() {
+		assertThat(WithOptional.INSTANCE.string()).hasValue("str");
+		assertThat(WithOptional.INSTANCE.looong()).hasValue(123456L);
+		assertThat(WithOptional.INSTANCE.empty()).isEmpty();
+	}
+
+	@Test
+	public void complex() {
+		assertThatThrownBy(() -> ConfijBuilder.of(Complex.class)
+				.build()).isInstanceOf(ConfijBindingException.class)
+				.hasMessageContaining(WithOptional.class.getSimpleName());
+	}
+}

--- a/confij-core/src/test/java/ch/kk7/confij/binding/values/OptionalMapperTest.java
+++ b/confij-core/src/test/java/ch/kk7/confij/binding/values/OptionalMapperTest.java
@@ -35,6 +35,7 @@ public class OptionalMapperTest implements WithAssertions {
 
 	@Test
 	public void complex() {
+		// TODO: would be desirable to work with complex types, too... here we just verify the exception type
 		assertThatThrownBy(() -> ConfijBuilder.of(Complex.class)
 				.build()).isInstanceOf(ConfijBindingException.class)
 				.hasMessageContaining(WithOptional.class.getSimpleName());

--- a/confij-core/src/test/java/ch/kk7/confij/template/SimpleVariableResolverTest.java
+++ b/confij-core/src/test/java/ch/kk7/confij/template/SimpleVariableResolverTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-class DefaultResolverTest implements WithAssertions, SysPropertyAssertions {
+class SimpleVariableResolverTest implements WithAssertions, SysPropertyAssertions {
 
 	private static String resolve(String template, String... x) {
 		NodeBindingContext settings = NodeBindingContext.newDefaultSettings();
@@ -25,7 +25,7 @@ class DefaultResolverTest implements WithAssertions, SysPropertyAssertions {
 		}
 		ConfijNode config = ConfijNode.newRootFor(format)
 				.initializeFromMap(map);
-		return new DefaultResolver().resolveValue(config, template);
+		return new SimpleVariableResolver().resolveValue(config, template);
 	}
 
 	private static AbstractStringAssert<?> assertResolve(String template, String... x) {

--- a/confij-core/src/test/java/ch/kk7/confij/validation/NonNullValidatorTest.java
+++ b/confij-core/src/test/java/ch/kk7/confij/validation/NonNullValidatorTest.java
@@ -1,0 +1,62 @@
+package ch.kk7.confij.validation;
+
+import ch.kk7.confij.ConfijBuilder;
+import ch.kk7.confij.annotation.Default;
+import ch.kk7.confij.source.env.PropertiesSource;
+import ch.kk7.confij.validation.NonNullValidator.Nullable;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.UUID;
+
+public class NonNullValidatorTest implements WithAssertions {
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ElementType.METHOD, ElementType.TYPE})
+	@interface Null {
+	}
+
+	interface WithNulls {
+		String nothing();
+
+		@Default("a default")
+		String hasDefault();
+
+		@Nullable
+		String nullalbe();
+
+		@Null
+		String customNull();
+	}
+
+	private static final String FIELD_NAME = "nothing";
+
+	@Test
+	public void defaultBuilderAllowsNull() {
+		assertThat(ConfijBuilder.of(WithNulls.class)
+				.build()
+				.nothing()).isNull();
+	}
+
+	@Test
+	public void nullNotAllowed() {
+		assertThatThrownBy(() -> ConfijBuilder.of(WithNulls.class)
+				.validateNonNull()
+				.build()).hasMessageContaining("null")
+				.hasMessageContaining(FIELD_NAME);
+	}
+
+	@Test
+	public void okIfNotNull() {
+		String value = UUID.randomUUID() + "";
+		assertThat(ConfijBuilder.of(WithNulls.class)
+				.validateNonNull()
+				.loadFrom(PropertiesSource.of(FIELD_NAME, value))
+				.build()
+				.nothing()).isEqualTo(value);
+	}
+}

--- a/confij-core/src/test/java/ch/kk7/confij/validation/NonNullValidatorTest.java
+++ b/confij-core/src/test/java/ch/kk7/confij/validation/NonNullValidatorTest.java
@@ -12,6 +12,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Optional;
 import java.util.UUID;
 
 public class NonNullValidatorTest implements WithAssertions {
@@ -32,6 +33,8 @@ public class NonNullValidatorTest implements WithAssertions {
 
 		@Null
 		String customNullAnnotationIsOk();
+
+		Optional<String> anOptional();
 	}
 
 	@NotNull
@@ -47,9 +50,10 @@ public class NonNullValidatorTest implements WithAssertions {
 
 	@Test
 	public void defaultBuilderAllowsNull() {
-		assertThat(ConfijBuilder.of(WithNulls.class)
-				.build()
-				.aField()).isNull();
+		WithNulls test = ConfijBuilder.of(WithNulls.class)
+				.build();
+		assertThat(test.aField()).isNull();
+		assertThat(test.anOptional()).isEmpty();
 	}
 
 	@Test

--- a/confij-core/src/test/java/ch/kk7/confij/validation/NonNullValidatorTest.java
+++ b/confij-core/src/test/java/ch/kk7/confij/validation/NonNullValidatorTest.java
@@ -59,7 +59,7 @@ public class NonNullValidatorTest implements WithAssertions {
 	@Test
 	public void nullNotAllowedAsDefinedInBuilder() {
 		assertThatThrownBy(() -> ConfijBuilder.of(WithNulls.class)
-				.validateNonNull()
+				.validateOnlyWith(NonNullValidator.initiallyNotNull())
 				.build()).hasMessageContaining("null")
 				.hasMessageContaining(FIELD_NAME);
 	}
@@ -68,7 +68,7 @@ public class NonNullValidatorTest implements WithAssertions {
 	public void okIfNotNullAsDefinedInBuilder() {
 		String value = UUID.randomUUID() + "";
 		assertThat(ConfijBuilder.of(WithNulls.class)
-				.validateNonNull()
+				.validateOnlyWith(NonNullValidator.initiallyNotNull())
 				.loadFrom(PropertiesSource.of(FIELD_NAME, value))
 				.build()
 				.aField()).isEqualTo(value);

--- a/confij-documentation/src/docs/asciidoc/binding.adoc
+++ b/confij-documentation/src/docs/asciidoc/binding.adoc
@@ -43,6 +43,7 @@ The default mapping behavior attempts to map from string to target type in the f
   java.io.File
   java.time.Duration
   java.time.Period
+  java.util.Optional
   ...
 
 . all Enum-types based on the Enum's name
@@ -69,7 +70,6 @@ include::{src}[tag=base64-mapping]
 ==== Comma Separated [[separated-mapping]]
 
 `@Separated` expects to bind a delimited string to an array or collection of arbitrary type.
-
 
 .@Separated as a short-form for collection types
 ====

--- a/confij-documentation/src/docs/asciidoc/validation.adoc
+++ b/confij-documentation/src/docs/asciidoc/validation.adoc
@@ -1,6 +1,34 @@
-= Miscellaneous
+= Post-Processing
 :src: ../../test/java/ch/kk7/confij/docs/Validation.java
 :home: ../../test/home
+
+== Non-Null Validator [[non-null-validator]]
+
+A recursive non-null validator is part of core. It verifies that the final configuration has all values set.
+It will not complain about null-values per default. To activate it add any `@NotNull` or `@NonNull` annotation to your config definition.
+Add such an annotation to your configuration root to apply it everywhere.
+Any annotation named alike will do as long as it is available at runtime.
+
+.Non-Null Validator activation
+====
+[source]
+----
+include::{src}[tag=notnull-interface]
+----
+====
+
+Non-null is enforced for all child-configuration values as well. To again allow for null values, use the opposite `@Nullable`.
+Core provides the `@NonNullValidator.NotNull` but you can also restrict yourself to Hibernate annotations.
+
+HINT: It is recommended to use `Optional<>` to explicitly mark optional configuration values instead of `@Nullable`.
+
+.Disable the Non-Null Validator globally
+====
+[source]
+----
+include::{src}[tag=notnull-disabled-builder]
+----
+====
 
 == JSR303 Validator
 
@@ -17,10 +45,13 @@ include::{src}[tag=jsr303-interface]
 ----
 ====
 
-WARNING: `{group}:confij-validation` depends on `hibernate-validator` >= 6.1 in order to support non-getter properties
+The JSR303 validator works together with the <<non-null-validator>>, however this means that the semantics of `@NonNull` is applied
+recursively to all child-nodes, which is usually desirable for configurations.
+
+WARNING: `{group}:confij-validation` depends on `hibernate-validator` >= 6.1 in order to support non-getter properties, too.
 
 == Logging
 
-ConfiJ core relies on `java.util.logging` (JUL) ony due to it's zero-dependency strategy.
+ConfiJ core relies on `java.util.logging` (JUL) only due to it's zero-dependency strategy.
 If `{group}:confij-slf4j` is found on the classpath, logging uses the slf4j-framework.
 To support a custom logging-framework, register a <<serviceloader>> for `ConfijLogFactory`.

--- a/confij-documentation/src/docs/asciidoc/validation.adoc
+++ b/confij-documentation/src/docs/asciidoc/validation.adoc
@@ -6,7 +6,8 @@
 
 A recursive non-null validator is part of core. It verifies that the final configuration has all values set.
 It will not complain about null-values per default. To activate it add any `@NotNull` or `@NonNull` annotation to your config definition.
-Add such an annotation to your configuration root to apply it everywhere.
+Add such an annotation to your configuration root to apply it everywhere as non-null is enforced in all child-configuration values as well.
+To again allow for null values, use the opposite `@Nullable`.
 Any annotation named alike will do as long as it is available at runtime.
 
 .Non-Null Validator activation
@@ -17,10 +18,12 @@ include::{src}[tag=notnull-interface]
 ----
 ====
 
-Non-null is enforced for all child-configuration values as well. To again allow for null values, use the opposite `@Nullable`.
-Core provides the `@NonNullValidator.NotNull` but you can also restrict yourself to Hibernate annotations.
+TIP: It is recommended to use `Optional<>` to explicitly mark optional configuration values instead of `@Nullable`.
 
-HINT: It is recommended to use `Optional<>` to explicitly mark optional configuration values instead of `@Nullable`.
+Core provides a `@NonNullValidator.Nullable` annotation but you can also restrict yourself to Hibernate annotations in case you are
+using the <<jsr303-validator>> already.
+
+This validator can be disabled for the whole configuration:
 
 .Disable the Non-Null Validator globally
 ====
@@ -30,7 +33,7 @@ include::{src}[tag=notnull-disabled-builder]
 ----
 ====
 
-== JSR303 Validator
+== JSR303 Validator [[jsr303-validator]]
 
 NOTE: JSR303 Validator format requires the `{group}:confij-validation` maven artifact.
 

--- a/confij-documentation/src/test/home/server.properties
+++ b/confij-documentation/src/test/home/server.properties
@@ -1,3 +1,3 @@
-# server.properties
+# content of a file named server.properties
 name=deepthough
 externalUrl=https://example.com:8042/think

--- a/confij-documentation/src/test/java/ch/kk7/confij/docs/Templates.java
+++ b/confij-documentation/src/test/java/ch/kk7/confij/docs/Templates.java
@@ -2,10 +2,10 @@ package ch.kk7.confij.docs;
 
 import ch.kk7.confij.annotation.Default;
 import ch.kk7.confij.annotation.VariableResolver;
-import ch.kk7.confij.template.NoopResolver.NoopVariableResolver;
+import ch.kk7.confij.template.NoopValueResolver.NoopResolver;
 import ch.kk7.confij.ConfijBuilder;
 import ch.kk7.confij.source.env.PropertiesSource;
-import ch.kk7.confij.tree.ConfijNode;
+import ch.kk7.confij.template.ValueResolver;import ch.kk7.confij.tree.ConfijNode;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
@@ -82,13 +82,13 @@ public class Templates implements WithAssertions {
 
 	// tag::noop[]
 	interface Noop {
-		@NoopVariableResolver
+		@NoopResolver
 		String canContainDollar();
 	}
 	// end::noop[]
 
 	// tag::global-noop[]
-	@NoopVariableResolver
+	@NoopResolver
 	interface GlobalNoop {
 		String canContainDollar();
 	}
@@ -116,7 +116,7 @@ public class Templates implements WithAssertions {
 	}
 
 	// tag::customresolver[]
-	static class FooResolver implements ch.kk7.confij.template.VariableResolver {
+	static class FooResolver implements ValueResolver {
 		@Override
 		public String resolveValue(ConfijNode baseLeaf, String valueToResolve) {
 			return "foo";

--- a/confij-documentation/src/test/java/ch/kk7/confij/docs/Validation.java
+++ b/confij-documentation/src/test/java/ch/kk7/confij/docs/Validation.java
@@ -1,19 +1,23 @@
 package ch.kk7.confij.docs;
 
 import ch.kk7.confij.ConfijBuilder;
+import ch.kk7.confij.source.env.PropertiesSource;
 import ch.kk7.confij.validation.ConfijValidationException;
+import ch.kk7.confij.validation.NonNullValidator.Nullable;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolationException;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+import java.util.Optional;
 
 public class Validation implements WithAssertions {
 
 	// tag::jsr303-interface[]
-	interface Validated {
-		@NotNull
+	interface Jsr303Validated {
+		@NotEmpty
 		String mandatory();
 		@Pattern(regexp = "[A-Z]*")
 		String uppercase();
@@ -21,9 +25,39 @@ public class Validation implements WithAssertions {
 	// end::jsr303-interface[]
 
 	@Test
-	public void isValidated() {
-		assertThatThrownBy(() -> ConfijBuilder.of(Validated.class)
+	public void isJrs303Validated() {
+		assertThatThrownBy(() -> ConfijBuilder.of(Jsr303Validated.class)
 				.build()).isInstanceOf(ConfijValidationException.class)
 				.hasCauseExactlyInstanceOf(ConstraintViolationException.class);
+	}
+
+	// tag::notnull-interface[]
+	@NotNull
+	interface NothingIsNull {
+		String willCrashIfNull();
+		@Nullable Long explicitlyNullable();
+		Optional<Integer> allowedToBeEmpty();
+	}
+	// end::notnull-interface[]
+
+	@Test
+	public void isNotNullValidated() {
+		assertThatThrownBy(() -> ConfijBuilder.of(NothingIsNull.class)
+        				.build()).isInstanceOf(ConfijValidationException.class);
+		assertThat(ConfijBuilder.of(NothingIsNull.class)
+								.loadFrom(PropertiesSource.of("willCrashIfNull", "xxx"))
+                				.build().willCrashIfNull()).isEqualTo("xxx");
+		assertThatThrownBy(() -> ConfijBuilder.of(NothingIsNull.class)
+                				.build()).isInstanceOf(ConfijValidationException.class);
+	}
+
+	@Test
+	public void isNotNullDisabled() {
+		assertThat(
+			// tag::notnull-disabled-builder[]
+			ConfijBuilder.of(NothingIsNull.class).validationAllowsNull().build()
+			// end::notnull-disabled-builder[]
+			.willCrashIfNull()
+		).isNull();
 	}
 }

--- a/confij-documentation/src/test/java/ch/kk7/confij/docs/Validation.java
+++ b/confij-documentation/src/test/java/ch/kk7/confij/docs/Validation.java
@@ -1,6 +1,7 @@
 package ch.kk7.confij.docs;
 
 import ch.kk7.confij.ConfijBuilder;
+import ch.kk7.confij.validation.ConfijValidationException;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
@@ -22,6 +23,7 @@ public class Validation implements WithAssertions {
 	@Test
 	public void isValidated() {
 		assertThatThrownBy(() -> ConfijBuilder.of(Validated.class)
-				.build()).isInstanceOf(ConstraintViolationException.class);
+				.build()).isInstanceOf(ConfijValidationException.class)
+				.hasCauseExactlyInstanceOf(ConstraintViolationException.class);
 	}
 }

--- a/confij-git/build.gradle
+++ b/confij-git/build.gradle
@@ -5,6 +5,6 @@ dependencies {
 	testImplementation("junit:junit:4.13") {
 		because 'jgit.junit depends on JUnit4'
 	}
-	testImplementation "org.eclipse.jgit:org.eclipse.jgit.junit.http:5.6.0.201912101111-r"
+	testImplementation "org.eclipse.jgit:org.eclipse.jgit.junit.http:5.7.0.202003110725-r"
 	testImplementation "org.eclipse.jgit:org.eclipse.jgit.junit.ssh:5.7.0.202003110725-r"
 }

--- a/confij-git/src/test/java/ch/kk7/confij/source/resource/GitResourceProviderFileTest.java
+++ b/confij-git/src/test/java/ch/kk7/confij/source/resource/GitResourceProviderFileTest.java
@@ -5,6 +5,7 @@ import org.assertj.core.api.WithAssertions;
 import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -84,6 +85,7 @@ class GitResourceProviderFileTest implements WithAssertions {
 		assertThatThrownBy(() -> git.read(uri)).isInstanceOf(ConfijSourceException.class);
 	}
 
+	@Disabled("unstable due to lock files preventing file move")
 	@Test
 	public void tmpRepoIsRemovedAtRuntimeRecovers() throws Exception {
 		testGit.addAndCommit();
@@ -93,7 +95,9 @@ class GitResourceProviderFileTest implements WithAssertions {
 		// move away
 		File currentTempDir = git.uriToGitSettings(fileUri)
 				.getLocalDir();
-		currentTempDir.renameTo(new File(currentTempDir.getParentFile(), GitResourceProvider.TEMP_DIR_PREFIX + "moved"));
+		File movedDir = new File(currentTempDir.getParentFile(), GitResourceProvider.TEMP_DIR_PREFIX + "moved");
+		assertThat(currentTempDir).exists();
+		assertThat(currentTempDir.renameTo(movedDir)).isTrue();
 		assertThat(currentTempDir).doesNotExist();
 
 		assertThat(git.read(fileUri)).isEqualTo(commit2.getShortMessage());
@@ -156,6 +160,7 @@ class GitResourceProviderFileTest implements WithAssertions {
 	public void getFileForSeedIsStable() {
 		assertThat(git.getFileForSeed("fuu")).isEqualTo(git.getFileForSeed("fuu"))
 				.isNotEqualTo(git.getFileForSeed("bar"));
+		//noinspection ConstantConditions
 		assertThatThrownBy(() -> git.getFileForSeed(null)).isInstanceOf(NullPointerException.class);
 	}
 }

--- a/confij-validation/src/main/java/ch/kk7/confij/validation/JSR303Validator.java
+++ b/confij-validation/src/main/java/ch/kk7/confij/validation/JSR303Validator.java
@@ -19,6 +19,7 @@ public class JSR303Validator implements ConfijValidator {
 	protected Validator newValidator() {
 		return Validation.byProvider(HibernateValidator.class)
 				.configure()
+				.failFast(false)
 				.getterPropertySelectionStrategy(new NoPrefixGetterPropertySelectionStrategy())
 				.messageInterpolator(new ParameterMessageInterpolator())
 				.buildValidatorFactory()

--- a/confij-validation/src/main/java/ch/kk7/confij/validation/JSR303Validator.java
+++ b/confij-validation/src/main/java/ch/kk7/confij/validation/JSR303Validator.java
@@ -1,5 +1,6 @@
 package ch.kk7.confij.validation;
 
+import ch.kk7.confij.binding.BindingResult;
 import com.google.auto.service.AutoService;
 import lombok.Value;
 import org.hibernate.validator.HibernateValidator;
@@ -13,7 +14,7 @@ import java.util.Set;
 
 @Value
 @AutoService(ConfijValidator.class)
-public class JSR303Validator implements ConfijValidator {
+public class JSR303Validator<T> implements ConfijValidator<T> {
 	Validator validator = newValidator();
 
 	protected Validator newValidator() {
@@ -27,7 +28,8 @@ public class JSR303Validator implements ConfijValidator {
 	}
 
 	@Override
-	public void validate(Object config) {
+	public void validate(BindingResult<T> bindingResult) {
+		T config = bindingResult.getValue();
 		final Set<ConstraintViolation<Object>> constraintViolations = validator.validate(config);
 		if (!constraintViolations.isEmpty()) {
 			ConstraintViolationException originalException = new ConstraintViolationException(constraintViolations);

--- a/confij-validation/src/main/java/ch/kk7/confij/validation/JSR303Validator.java
+++ b/confij-validation/src/main/java/ch/kk7/confij/validation/JSR303Validator.java
@@ -1,6 +1,7 @@
 package ch.kk7.confij.validation;
 
 import com.google.auto.service.AutoService;
+import lombok.Value;
 import org.hibernate.validator.HibernateValidator;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 
@@ -10,13 +11,10 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import java.util.Set;
 
+@Value
 @AutoService(ConfijValidator.class)
 public class JSR303Validator implements ConfijValidator {
-	private final Validator validator;
-
-	public JSR303Validator() {
-		validator = newValidator();
-	}
+	Validator validator = newValidator();
 
 	protected Validator newValidator() {
 		return Validation.byProvider(HibernateValidator.class)
@@ -30,9 +28,9 @@ public class JSR303Validator implements ConfijValidator {
 	@Override
 	public void validate(Object config) {
 		final Set<ConstraintViolation<Object>> constraintViolations = validator.validate(config);
-		// TODO: patch rootBeanClass from rootBeanClass=class com.sun.proxy.$Proxy16 to something readable
 		if (!constraintViolations.isEmpty()) {
-			throw new ConstraintViolationException(constraintViolations);
+			ConstraintViolationException originalException = new ConstraintViolationException(constraintViolations);
+			throw new ConfijValidationException("validation failed for {} with {}", config, constraintViolations, originalException);
 		}
 	}
 }

--- a/confij-validation/src/test/java/ch/kk7/confij/validation/JSR303ValidatorTest.java
+++ b/confij-validation/src/test/java/ch/kk7/confij/validation/JSR303ValidatorTest.java
@@ -54,15 +54,16 @@ class JSR303ValidatorTest implements WithAssertions {
 	public void testOneInvalid() {
 		ConfijBuilder<ValidatedConfig> builder = ConfijBuilder.of(ValidatedConfig.class)
 				.loadFrom(new PropertiesSource().with("anInt", "23"));
-		assertThatExceptionOfType(ConstraintViolationException.class).isThrownBy(builder::build)
-				.satisfies(e -> assertThat(e.getConstraintViolations()).hasSize(1));
+		assertThatExceptionOfType(ConfijValidationException.class).isThrownBy(builder::build)
+				.withCauseExactlyInstanceOf(ConstraintViolationException.class)
+				.satisfies(e -> assertThat(((ConstraintViolationException) e.getCause()).getConstraintViolations()).hasSize(1));
 	}
 
 	@Test
 	public void testNestedInvalid() {
 		ConfijBuilder<ValidatedConfig> builder = ConfijBuilder.of(ValidatedConfig.class)
 				.loadFrom(new PropertiesSource().with("nested.aString", ""));
-		assertThatExceptionOfType(ConstraintViolationException.class).isThrownBy(builder::build);
+		assertThatExceptionOfType(ConfijValidationException.class).isThrownBy(builder::build);
 	}
 
 	@Test
@@ -79,8 +80,8 @@ class JSR303ValidatorTest implements WithAssertions {
 						.with("aSet.0.aString", "")
 						.with("aSet.1.aString", "I'm valid")
 						.with("aSet.2.aString", ""));
-		assertThatExceptionOfType(ConstraintViolationException.class).isThrownBy(builder::build);
-		// TODO: actually not? .satisfies(e -> assertThat(e.getConstraintViolations()).hasSize(2));
+		assertThatExceptionOfType(ConfijValidationException.class).isThrownBy(builder::build)
+				.withCauseExactlyInstanceOf(ConstraintViolationException.class);
 	}
 
 	@Test

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lombok.config
+++ b/lombok.config
@@ -1,2 +1,3 @@
 config.stopBubbling = true
 lombok.addLombokGeneratedAnnotation = true
+lombok.log.custom.declaration = ch.kk7.confij.logging.ConfijLogger.getLogger(TYPE)(TOPIC)


### PR DESCRIPTION
Breaking change for validators as it is now possible to access the binding configuration of the final configuration.
A non-null validator was introduced, which is an ideological extension of the JSR303 validator (think of it as everything `@Valid` and `@NotNull` being inherited by child configurations.
Additional introduction of an `Optional<>` leaf-binding to complement the not-null validator (or as an alternative to `@Nullable`). Optional is only available for leaf-types (not for optional interfaces as of now).

Fixes #15, #2