### PR TITLE
property source fixes for invalid keys

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: checkout 📥
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # all commits, required for propper versioning
 
       - name: JDK${{ matrix.java }} ☕
         uses: actions/setup-java@v1

--- a/README.md
+++ b/README.md
@@ -12,22 +12,21 @@ configurations from various sources in a type-safe manner.
 This includes features such as
 
 - configuration definition as interfaces
-- support for various source formats: properties, YAML, HOCON, JSON
-- load from: Git, File, Classpath, HTTP, system properties, environment variables
-- load from various sources (pipelines) with different merge strategies
-- powerfull support for nested configurations
 - even as lists/maps/arrays/... of nested configurations
+- support for various source formats: properties, YAML, HOCON, JSON
+- load from various sources at once with different merge strategies
+- load from: Git, File, Classpath, HTTP, system properties, environment variables
 - binding support to various immutable property types like URL, DateTime, Duration, enums, Period,...
 - templating support (variable substitutions), even within paths
 - plugin support for more formats and sources
 - JSR303 bean validation
-- minimal dependencies
+- no dependencies
 
 ## Example
 
 Sample configuration of a house with nested properties, defaults and validation-annotations
 ```java
-interface House {
+interface HouseConfiguration {
 	@Default("true")
 	boolean hasRoof();
 
@@ -57,7 +56,7 @@ Load an immutable configuration instance with base settings from
 a property file on the classpath and override it with a YAML configuration from
 the local filesystem.
 ```java
-House johnsHouse = ConfijBuilder.of(House.class)
+HouseConfiguration johnsHouse = ConfijBuilder.of(HouseConfiguration.class)
 	.loadFrom("classpath:house.properties", "johnshouse.yaml")
 	.build();
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 plugins {
 	id 'org.ajoberstar.reckon' version '0.12.0'
 	id 'com.github.ben-manes.versions' version '0.29.0' // task: dependencyUpdates
-	id 'org.sonarqube' version '2.8'
+	id 'org.sonarqube' version '3.0'
 	id 'org.asciidoctor.jvm.convert' version '3.2.0' apply false
 	id 'com.jfrog.bintray' version '1.8.5' apply false
 	id 'com.github.johnrengelman.shadow' version '6.0.0' apply false
@@ -91,6 +91,7 @@ subprojects {
 		testImplementation "org.junit.jupiter:junit-jupiter-params:${junitVersion}"
 		testImplementation "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
 		testImplementation "org.assertj:assertj-core:3.16.1"
+		testImplementation "com.github.stefanbirkner:system-lambda:1.0.0"
 
 		testRuntimeOnly 'ch.qos.logback:logback-classic:1.2.3'
 	}

--- a/confij-core/src/main/java/ch/kk7/confij/source/any/AnySource.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/any/AnySource.java
@@ -7,6 +7,7 @@ import ch.kk7.confij.source.ConfijSourceException;
 import ch.kk7.confij.template.ValueResolver;
 import ch.kk7.confij.tree.ConfijNode;
 import lombok.Data;
+import lombok.ToString;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -23,6 +24,7 @@ import java.util.Optional;
  */
 @Data
 public class AnySource implements ConfijSource {
+	@ToString.Exclude
 	private final List<ConfijSourceBuilder> sourceBuilders;
 	private final String pathTemplate;
 
@@ -62,8 +64,9 @@ public class AnySource implements ConfijSource {
 		try {
 			confijSource.override(rootNode);
 		} catch (ConfijSourceException e) {
-			throw new ConfijSourceException("The {} write a new configuration using the {} {}", this, ConfijSource.class.getSimpleName(),
-					confijSource, e);
+			throw new ConfijSourceException("Failed reading source from path `{}` using {} (" +
+					"either fix the content of this source or write a new ServiceLoader implementing {}): {}", path, this,
+					ConfijSource.class.getSimpleName(), e.getMessage(), e);
 		}
 	}
 }

--- a/confij-core/src/main/java/ch/kk7/confij/source/env/EnvvarSource.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/env/EnvvarSource.java
@@ -23,7 +23,7 @@ public class EnvvarSource extends PropertiesFormat implements ConfijSource, Conf
 	public void override(ConfijNode rootNode) {
 		if (deepMap == null) {
 			// envvars don't change: we can cache them forever
-			deepMap = flatToNestedMapWithPrefix(rootNode.getConfig(), System.getenv());
+			deepMap = flatToNestedMapWithPrefix(System.getenv());
 		}
 		overrideWithDeepMap(rootNode, deepMap);
 	}

--- a/confij-core/src/main/java/ch/kk7/confij/source/format/MapAndStringValidator.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/format/MapAndStringValidator.java
@@ -17,7 +17,8 @@ public class MapAndStringValidator {
 		validateObj(null, src, node.getConfig());
 	}
 
-	protected void validateObj(String path, Object src, @NonNull NodeDefinition definition) {
+	@SuppressWarnings("unchecked")
+	protected void validateObj(String path, Object src, NodeDefinition definition) {
 		if (src instanceof String || src == null) {
 			validateDefinition(path, (String) src, definition);
 		} else if (src instanceof Map) {
@@ -27,7 +28,7 @@ public class MapAndStringValidator {
 		}
 	}
 
-	protected void validateDefinition(String path, @NonNull Map<String, Object> src, @NonNull NodeDefinition definition) {
+	protected void validateDefinition(String path, Map<String, Object> src, NodeDefinition definition) {
 		// note: the src is not required to have all mandatory keys
 		for (Entry<String, Object> entry: src.entrySet()) {
 			String childPath = (path==null ? "" : path + SEP) + entry.getKey();
@@ -42,9 +43,9 @@ public class MapAndStringValidator {
 		}
 	}
 
-	protected void validateDefinition(String path, String src, @NonNull NodeDefinition definition) {
+	protected void validateDefinition(String path, String src, NodeDefinition definition) {
 		if (!definition.isValueHolder()) {
-			throw new ConfijBindingException("unexpected leaf-value at {} ({}). expected a key instead. mandatory keys are {}",
+			throw new ConfijBindingException("unexpected leaf-value at key '{}' (value: {}). expected a Map instead. mandatory keys are {}",
 					path == null ? SEP : path, src, definition.getMandatoryKeys());
 
 		}

--- a/confij-core/src/main/java/ch/kk7/confij/source/format/MapAndStringValidator.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/format/MapAndStringValidator.java
@@ -1,0 +1,53 @@
+package ch.kk7.confij.source.format;
+
+import ch.kk7.confij.binding.ConfijBindingException;
+import ch.kk7.confij.tree.ConfijNode;
+import ch.kk7.confij.tree.NodeDefinition;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+@UtilityClass
+public class MapAndStringValidator {
+	private final String SEP = ".";
+
+	public void validateDefinition(Object src, ConfijNode node) throws ConfijBindingException {
+		validateObj(null, src, node.getConfig());
+	}
+
+	protected void validateObj(String path, Object src, @NonNull NodeDefinition definition) {
+		if (src instanceof String || src == null) {
+			validateDefinition(path, (String) src, definition);
+		} else if (src instanceof Map) {
+			validateDefinition(path, (Map) src, definition);
+		} else {
+			throw new IllegalArgumentException("expected an instance of String or Map at config path " + path + ", but got " + src);
+		}
+	}
+
+	protected void validateDefinition(String path, @NonNull Map<String, Object> src, @NonNull NodeDefinition definition) {
+		// note: the src is not required to have all mandatory keys
+		for (Entry<String, Object> entry: src.entrySet()) {
+			String childPath = (path==null ? "" : path + SEP) + entry.getKey();
+			final NodeDefinition childDefinition;
+			try {
+				childDefinition = definition.definitionForChild(entry.getKey());
+			} catch (ConfijBindingException e) {
+				throw new ConfijBindingException("unexpected content at configuration path '{}' (value: {}): " + e.getMessage(),
+						childPath, src, e);
+			}
+			validateObj(childPath, entry.getValue(), childDefinition);
+		}
+	}
+
+	protected void validateDefinition(String path, String src, @NonNull NodeDefinition definition) {
+		if (!definition.isValueHolder()) {
+			throw new ConfijBindingException("unexpected leaf-value at {} ({}). expected a key instead. mandatory keys are {}",
+					path == null ? SEP : path, src, definition.getMandatoryKeys());
+
+		}
+	}
+
+}

--- a/confij-core/src/main/java/ch/kk7/confij/source/format/PropertiesFormat.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/format/PropertiesFormat.java
@@ -24,16 +24,6 @@ public class PropertiesFormat implements ConfijSourceFormat {
 
 	private String globalPrefix = null;
 
-	public static final String NOOP_PREFIX = "-";
-
-	public PropertiesFormat setGlobalPrefix(String prefix) {
-		if (NOOP_PREFIX.equals(prefix)) {
-			prefix = null;
-		}
-		globalPrefix = prefix;
-		return this;
-	}
-
 	@Override
 	public void override(ConfijNode rootNode, String configAsStr) {
 		final Properties properties = new Properties();

--- a/confij-core/src/main/java/ch/kk7/confij/tree/NodeDefinition.java
+++ b/confij-core/src/main/java/ch/kk7/confij/tree/NodeDefinition.java
@@ -33,7 +33,7 @@ public abstract class NodeDefinition {
 	 * @return an instance of self for a given named child node.
 	 */
 	@NonNull
-	public abstract NodeDefinition definitionForChild(String configKey);
+	public abstract NodeDefinition definitionForChild(String configKey) throws ConfijBindingException;
 
 	/**
 	 * @return a set of required names/keys for child nodes
@@ -52,7 +52,7 @@ public abstract class NodeDefinition {
 		@NonNull
 		@Override
 		public NodeDefinition definitionForChild(String configKey) {
-			throw new ConfijBindingException("a leaf node isn't allowed to have children, not even for '{}'", configKey);
+			throw new ConfijBindingException("a leaf node isn't allowed to have children. this key named '{}' is invalid.", configKey);
 		}
 
 		@Override

--- a/confij-core/src/test/java/ch/kk7/confij/source/env/EnvvarSourceTest.java
+++ b/confij-core/src/test/java/ch/kk7/confij/source/env/EnvvarSourceTest.java
@@ -51,7 +51,7 @@ class EnvvarSourceTest implements WithAssertions {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {"PRE_", "PRE_xy_", "PRE__", "PRE_others_cannot_map_this", "PRE_others__"})
+	@ValueSource(strings = {"PRE_", "PRE_xy_", "PRE__", "PRE_others_cannot_map_this", "PRE_others__", "PRE_xy_invalid", "PRE_others"})
 	public void keysCannotBindToConfigStructure(String envvar) throws Exception {
 		SystemLambda.withEnvironmentVariable(envvar, "whatever")
 				.execute(() -> {

--- a/confij-core/src/test/java/ch/kk7/confij/source/env/EnvvarSourceTest.java
+++ b/confij-core/src/test/java/ch/kk7/confij/source/env/EnvvarSourceTest.java
@@ -1,0 +1,75 @@
+package ch.kk7.confij.source.env;
+
+import ch.kk7.confij.ConfijBuilder;
+import ch.kk7.confij.binding.ConfijBindingException;
+import ch.kk7.confij.common.GenericType;
+import ch.kk7.confij.source.ConfijSourceException;
+import com.github.stefanbirkner.systemlambda.SystemLambda;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Map;
+import java.util.UUID;
+
+class EnvvarSourceTest implements WithAssertions {
+	interface Config {
+		String xy();
+
+		Map<String, String> others();
+	}
+
+	@Test
+	public void withPrefix() throws Exception {
+		String value1 = UUID.randomUUID() + "";
+		String value2 = UUID.randomUUID() + "";
+		SystemLambda.withEnvironmentVariable("A_PREFIX_xy", value1)
+				.and("A_PREFIX_others_fuu.", value2)
+				.and("A_PREFIXORNORATALL_xy", "fuuuuu")
+				.execute(() -> {
+					Config config = ConfijBuilder.of(Config.class)
+							.loadFrom("env:A_PREFIX")
+							.build();
+					assertThat(config.xy()).isEqualTo(value1);
+					assertThat(config.others()).containsExactly(new SimpleEntry<>("fuu.", value2));
+				});
+	}
+
+	@Test
+	public void emptyStringEnvvar() throws Exception {
+		String value1 = UUID.randomUUID() + "";
+		SystemLambda.withEnvironmentVariable("A_PREFIX_others_", value1)
+				.and("_", "whatever")
+				.execute(() -> {
+					Config config = ConfijBuilder.of(Config.class)
+							.loadFrom("env:A_PREFIX")
+							.build();
+					assertThat(config.others()).containsEntry("", value1);
+				});
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"PRE_", "PRE_xy_", "PRE__", "PRE_others_cannot_map_this", "PRE_others__"})
+	public void keysCannotBindToConfigStructure(String envvar) throws Exception {
+		SystemLambda.withEnvironmentVariable(envvar, "whatever")
+				.execute(() -> {
+					assertThatThrownBy(() -> ConfijBuilder.of(Config.class)
+							.loadFrom("env:PRE")
+							.build()).isInstanceOf(ConfijBindingException.class);
+				});
+	}
+
+	@Test
+	public void keyConflictsAreSourceIssues() throws Exception {
+		SystemLambda.withEnvironmentVariable("PRE_a_b", "whatever")
+				.and("PRE_a", "whatever")
+				.execute(() -> assertThatThrownBy(() -> ConfijBuilder.of(new GenericType<Map<String, String>>() {
+				})
+						.loadFrom("env:PRE")
+						.build()).isInstanceOf(ConfijSourceException.class)
+						.hasMessageContaining("PRE_a"));
+	}
+
+}

--- a/confij-core/src/test/java/ch/kk7/confij/source/format/PropertiesFormatTest.java
+++ b/confij-core/src/test/java/ch/kk7/confij/source/format/PropertiesFormatTest.java
@@ -39,8 +39,8 @@ class PropertiesFormatTest implements WithAssertions {
 
 	@Test
 	public void flatmapSoloKey() {
-		assertThat(flatmapPrefixedBy("", "")).isEmpty();
-		assertThat(flatmapPrefixedBy("a.b.c=value", "")).containsOnlyKeys("a.b.c")
+		assertThat(flatmapPrefixedBy("", null)).isEmpty();
+		assertThat(flatmapPrefixedBy("a.b.c=value", null)).containsOnlyKeys("a.b.c")
 				.containsValue("value");
 		assertThat(flatmapPrefixedBy("a.b.c=value", "a")).containsOnlyKeys("b.c")
 				.containsValue("value");
@@ -56,17 +56,9 @@ class PropertiesFormatTest implements WithAssertions {
 	}
 
 	@Test
-	public void flatmapInvalidSoloKey() {
-		assertThatThrownBy(() -> flatmapPrefixedBy("a=value", null));
-		assertThatThrownBy(() -> flatmapPrefixedBy(null, "a"));
-		assertThatThrownBy(() -> flatmapPrefixedBy("a=value", "a"));
-		assertThatThrownBy(() -> flatmapPrefixedBy("a=value|a.b.c=value", "a"));
-	}
-
-	@Test
 	public void flatmapMultiKey() {
 		String testString = "a.b.c=value|a.x.y=value2|fuu=bar";
-		assertThat(flatmapPrefixedBy(testString, "")).containsOnlyKeys("a.b.c", "a.x.y", "fuu");
+		assertThat(flatmapPrefixedBy(testString, null)).containsOnlyKeys("a.b.c", "a.x.y", "fuu");
 		assertThat(flatmapPrefixedBy(testString, "a")).containsOnlyKeys("b.c", "x.y");
 		assertThat(flatmapPrefixedBy(testString, "a.b")).containsOnlyKeys("c");
 	}

--- a/confij-documentation/build.gradle
+++ b/confij-documentation/build.gradle
@@ -14,12 +14,16 @@ asciidoctor {
 			'reproducible': 'true',
 			'attribute-missing': 'warn'
 
+	doFirst {
+		attributes 'revnumberstable': "git tag -l --sort=-v:refname".execute().in.readLines().find {it ==~ /\d+\.\d+\.\d+/}
+	}
+
 	asciidoctorj {
 		baseDirFollowsSourceDir()
 		sources {
 			include 'index.adoc'
 		}
-		fatalWarnings missingIncludes()
+		fatalWarnings missingIncludes(), ~/missing attribute/
 	}
 }
 
@@ -27,4 +31,5 @@ tasks.assemble.dependsOn 'asciidoctor'
 
 test {
 	workingDir file('src/test/home')
+
 }

--- a/confij-documentation/src/docs/asciidoc/setup.adoc
+++ b/confij-documentation/src/docs/asciidoc/setup.adoc
@@ -3,10 +3,11 @@
 :home: ../../test/home
 
 ConfiJ requires Java 1.8 or later.
+It is modularly organized in order to reduce the amount of dependencies.
+`confij-core` itself has no external dependencies.
 
 == Repository
 ConfiJ maven artifacts are available on Bintray/JCenter.
-It is modularly organized in order to reduce the amount of dependencies.
 
 .Sample Gradle setup
 ====
@@ -17,10 +18,14 @@ repositories {
    jcenter()
 }
 dependencies {
-    compile '{group}:confij-core:{revnumber}'
+    implementation '{group}:confij-core:{revnumberstable}'
 }
 ----
 ====
+
+ifeval::[{revnumberstable}!={revnumber}]
+The latest snapshot version `{revnumber}` will be removed after 30 days.
+endif::[]
 
 == Quick Start
 .Getting started with interface configuration and ConfiJ-Builder
@@ -42,4 +47,4 @@ include::{home}/server.properties[]
 <3> Bind the source to a configuration instance of matching type
 
 The corresponding properties file must have the same attributes as in the interface.
-ConfiJ will make sure that no unknown keys are present and bind all configuration strings to their configuration types.
+ConfiJ will make sure no unknown keys are present and bind all configuration strings to their configuration types.

--- a/confij-documentation/src/docs/asciidoc/source.adoc
+++ b/confij-documentation/src/docs/asciidoc/source.adoc
@@ -4,9 +4,9 @@
 :home: ../../test/home
 
 == Source Pipelines
-ConfiJ sources are loaded one after the other.
+ConfiJ loads sources one after the other.
 Each consecutive source overrides (merges) attributes of the previous ones.
-Typically this is useful to load a set of default values first,
+Typically, this is useful to load a set of default values first,
 then continue with application specifics and environment specific values
 getting more and more detailed.
 Source types can be freely mixed, meaning you can load from classpath, then from a remote file, then from envionment variables and so on.
@@ -193,12 +193,12 @@ include::../../../../confij-hocon/src/test/resources/bnotrefa.conf[]
 ----
 ====
 
-=== Properties Format
+=== Properties Format [[properties-format]]
 
 Java properties files are part of the `{group}:confij-core` due to not having any 3rd party dependencies,
 but are otherwise not recommended, since it is a flat key-value format.
 
-Properties files can be loaded from all the <<resource-locations>>.
+Property files can be loaded from all <<resource-locations>>.
 The `AnySource` expects a case-insensitive file ending of `.properties`.
 
 .Nested configuration loading from properties file
@@ -212,19 +212,37 @@ include::{home}/nested.properties[]
 ----
 ====
 
-<1> Per default, nested configuration keys are separated with a dot form each other.
+<1> Per default, nested configuration keys are separated with a dot from each other.
 <2> Collection types simply require numerical keys (starting at 0).
 <3> Map types can use any key excluding the delimiter.
 
-=== Environment Variables Format
+=== Environment Variables and System Properties Format
 
-=== System Properties Format
+Environment variables and system properties work similar to the file based <<properties-format>>.
+System properties have to be dot separated, whereas envvars are underline separated.
+To read an envvar specify a URI like `env:<prefix>`, where every envvar to be considered
+must start with that prefix and will have that prefix stripped away.
+For example an envvar `FUU_bar_xy` with a prefix `FUU` is mapped to a property called `bar.xy` (case-sensitive).
 
-=== Logical Sources
+.Read configuration values from envvars and Java sys props
+====
+[source]
+----
+include::{src}[tag=envvarsyspropsource]
+----
+[source,bash]
+----
+include::{src}[tag=set-envvarsyspropsource]
+----
+====
+
+An often used alternative is to rely on <<templating>> to read specific envvars.
+
+// TODO: === Logical Sources
 
 == ConfiJ's ServiceLoaders [[serviceloader]]
 
-ConfiJ allows to utilize Java's https://docs.oracle.com/javase/8/docs/api/?java/util/ServiceLoader.html[ServiceLoader]
+ConfiJ allows utilizing Java's https://docs.oracle.com/javase/8/docs/api/?java/util/ServiceLoader.html[ServiceLoader]
 mechanism to register additional services like source formats or validators.
 All you have to do is to add the file with the service-interface name to META-INF/services.
 In this service file you list the fully qualified classnames of your constraint validator classes (one per line).

--- a/confij-documentation/src/docs/asciidoc/templates.adoc
+++ b/confij-documentation/src/docs/asciidoc/templates.adoc
@@ -9,7 +9,7 @@ Therefore it is possible for an unfinished configuration to contain undefined re
 
 Additionally some source paths are subject to templating (see <<anysource>>).
 
-== built-in Templating
+== built-in Templating [[templating]]
 
 Any property can contain placeholders wrapped in `${ }`.
 These referenced properties can themselves reference other properties.

--- a/confij-documentation/src/test/java/ch/kk7/confij/docs/Readme.java
+++ b/confij-documentation/src/test/java/ch/kk7/confij/docs/Readme.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 
 public class Readme extends DocTestBase {
 
-	interface House {
+	interface HouseConfiguration {
 		@Default("true")
 		boolean hasRoof();
 
@@ -45,7 +45,7 @@ public class Readme extends DocTestBase {
 
 	@Test
 	public void houseTest() {
-		House johnsHouse = ConfijBuilder.of(House.class)
+		HouseConfiguration johnsHouse = ConfijBuilder.of(HouseConfiguration.class)
 				.loadFrom("classpath:house.properties", "johnshouse.yaml")
 				.build();
 		assertThat(johnsHouse.chimneyCheckEvery()).isEqualTo(Period.ofYears(2));


### PR DESCRIPTION
If loading from any property-like source (file, envvar, sysprop),
with conflicting keys like `a.b=x` and `a=y`, which cannot be mapped
to a tree-structure it will now correctly complain instead of an NPE.
The binding checks (if a key actually is known to the config) is now
done in it's own step a bit later.
Also added documentation for property-like sources.

minor: documentation points to the latest stable version instead of a
 snapshot one.
minor: documentation updated since core doesn't have any dependencies