### PR TITLE
bugfix spaces in source uri

### DIFF
--- a/confij-core/src/main/java/ch/kk7/confij/pipeline/ConfijPipelineImpl.java
+++ b/confij-core/src/main/java/ch/kk7/confij/pipeline/ConfijPipelineImpl.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class ConfijPipelineImpl<T> implements ConfijPipeline<T> {
 	@NonNull List<ConfijSource> sources;
 	@NonNull ConfijSource defaultSource;
-	@NonNull ConfijValidator validator;
+	@NonNull ConfijValidator<T> validator;
 	@NonNull ConfigBinding<T> configBinding;
 	@NonNull NodeDefinition format;
 

--- a/confij-core/src/main/java/ch/kk7/confij/source/any/AnySource.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/any/AnySource.java
@@ -33,7 +33,7 @@ public class AnySource implements ConfijSource {
 		sourceBuilders = ServiceLoaderUtil.requireInstancesOf(ConfijSourceBuilder.class);
 	}
 
-	protected ValueResolver getResolver(ConfijNode rootNode) {
+	protected static ValueResolver getResolver(ConfijNode rootNode) {
 		return rootNode.getConfig()
 				.getNodeBindingContext()
 				.getValueResolver();

--- a/confij-core/src/main/java/ch/kk7/confij/source/any/AnySource.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/any/AnySource.java
@@ -41,8 +41,27 @@ public class AnySource implements ConfijSource {
 
 	protected URI resolveUri(ConfijNode rootNode) {
 		String actualPath = getResolver(rootNode).resolveValue(rootNode, pathTemplate);
+		// this part is a workaround to escape the URI instead of new URI(actualPath)
+		final String scheme;
+		String path;
+		final String fragment;
+		String[] schemeParts = actualPath.split(":", 2);
+		if (schemeParts.length == 1) {
+			scheme = null;
+			path = schemeParts[0];
+		} else {
+			scheme = schemeParts[0];
+			path = schemeParts[1];
+		}
+		String[] pathParts = path.split("#", 2);
+		if (pathParts.length == 1) {
+			fragment = null;
+		} else {
+			path = pathParts[0];
+			fragment = pathParts[1];
+		}
 		try {
-			return new URI(actualPath);
+			return new URI(scheme, path, fragment);
 		} catch (URISyntaxException e) {
 			throw new ConfijSourceException("The {} failed to resolve the path-template '{}' into a valid URI", this, pathTemplate, e);
 		}


### PR DESCRIPTION
Special (non-URI) chars were never escaped when reading from 'em.
minor: stable envvar test