### PR TITLE
ISO temporal date types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,13 +65,25 @@ subprojects {
 		withSourcesJar()
 	}
 
+	tasks.withType(JavaCompile) {
+		options.incremental = true
+	}
+
 	tasks.withType(AbstractArchiveTask) {
 		preserveFileTimestamps = false
 		reproducibleFileOrder = true
 	}
 
-	tasks.withType(JavaCompile) {
-		options.incremental = true
+	configurations.runtime {
+		resolutionStrategy {
+			failOnVersionConflict()
+		}
+	}
+
+	configurations.all {
+		resolutionStrategy {
+			failOnNonReproducibleResolution()
+		}
 	}
 
 	dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -159,6 +159,8 @@ allprojects {
 		}
 	}
 }
+// disable sonar analysis without secret (since secrets aren't availabe in PRs from forks)
+project.tasks['sonarqube'].enabled System.getenv('SONAR_TOKEN') != null
 project.tasks['sonarqube'].dependsOn jacocoRootReport
 
 // releases

--- a/confij-core/src/main/java/ch/kk7/confij/binding/leaf/LeafBinding.java
+++ b/confij-core/src/main/java/ch/kk7/confij/binding/leaf/LeafBinding.java
@@ -2,6 +2,7 @@ package ch.kk7.confij.binding.leaf;
 
 import ch.kk7.confij.binding.BindingResult;
 import ch.kk7.confij.binding.ConfigBinding;
+import ch.kk7.confij.binding.ConfijBindingException;
 import ch.kk7.confij.binding.values.ValueMapperInstance;
 import ch.kk7.confij.tree.NodeDefinition.NodeDefinitionLeaf;
 import ch.kk7.confij.tree.NodeBindingContext;
@@ -27,6 +28,14 @@ public class LeafBinding<T> implements ConfigBinding<T> {
 				.getNodeBindingContext()
 				.getValueResolver()
 				.resolveLeaf(leafNode);
-		return BindingResult.ofLeaf(valueMapper.fromString(strValue), leafNode);
+		final T converted;
+		try {
+			converted = valueMapper.fromString(strValue);
+		} catch (Exception e) {
+			throw new ConfijBindingException(
+					"failed to convert string '{}' to an actual configuration object at '{}'. message: {}",
+					strValue, leafNode.getUri(), e.getMessage(), e);
+		}
+		return BindingResult.ofLeaf(converted, leafNode);
 	}
 }

--- a/confij-core/src/main/java/ch/kk7/confij/binding/values/DateTimeMapper.java
+++ b/confij-core/src/main/java/ch/kk7/confij/binding/values/DateTimeMapper.java
@@ -1,32 +1,39 @@
 package ch.kk7.confij.binding.values;
 
-import ch.kk7.confij.annotation.ValueMapper;
-import ch.kk7.confij.binding.BindingType;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Locale.Category;
 import java.util.Optional;
 
+import ch.kk7.confij.annotation.ValueMapper;
+import ch.kk7.confij.binding.BindingType;
+
 public class DateTimeMapper implements ValueMapperFactory {
+
+	/**
+	 * to be put on any of the supported Temporal types to define the format of the string to be parsed.
+	 */
 	@Inherited
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ElementType.METHOD, ElementType.TYPE})
 	@ValueMapper(DateTimeMapper.class)
 	public @interface DateTime {
 		/**
-		 * @return A pattern for {@link DateTimeFormatter#ofPattern(String, Locale)}
+		 * @return A pattern for {@link DateTimeFormatter#ofPattern(String, Locale)}.
 		 */
-		String value() default "yyyy-MM-dd'T'HH:mm:ss.SXXX";
+		String value() default "";
 
 		/**
 		 * @return A locale string for {@link DateTimeFormatter#ofPattern(String, Locale)}
@@ -34,59 +41,53 @@ public class DateTimeMapper implements ValueMapperFactory {
 		String lang() default "";
 	}
 
-	@DateTime
-	private static final class AnnonHolder {
-	}
-
-	@RequiredArgsConstructor
-	public static class OffsetDateTimeMapperInstance implements ValueMapperInstance<OffsetDateTime> {
-		@NonNull
-		private final DateTimeFormatter dateTimeFormatter;
-
-		@Override
-		public OffsetDateTime fromString(String string) {
-			return OffsetDateTime.parse(string, dateTimeFormatter);
-		}
-	}
-
-	@RequiredArgsConstructor
-	public static class DateMapperInstance implements ValueMapperInstance<Date> {
-		@NonNull
-		private final OffsetDateTimeMapperInstance mapperInstance;
-
-		@Override
-		public Date fromString(String string) {
-			return Date.from(mapperInstance.fromString(string)
-					.toInstant());
-		}
-	}
-
 	@Override
 	public Optional<ValueMapperInstance<?>> maybeForType(BindingType bindingType) {
 		Class<?> type = bindingType.getResolvedType()
 				.getErasedType();
-		if (type.equals(Date.class)) {
-			return Optional.of(newDateMapperInstance(bindingType));
+		if (type.equals(ZonedDateTime.class)) {
+			DateTimeFormatter formatter = newDateTimeFormatter(bindingType, DateTimeFormatter.ISO_ZONED_DATE_TIME);
+			return Optional.of(x -> ZonedDateTime.parse(x, formatter));
 		}
 		if (type.equals(OffsetDateTime.class)) {
-			return Optional.of(newOffsetDateTimeMapperInstance(bindingType));
+			DateTimeFormatter formatter = newDateTimeFormatter(bindingType, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+			return Optional.of(x -> OffsetDateTime.parse(x, formatter));
+		}
+		if (type.equals(Instant.class)) {
+			DateTimeFormatter formatter = newDateTimeFormatter(bindingType, DateTimeFormatter.ISO_INSTANT);
+			return Optional.of(x -> formatter.parse(x, Instant::from));
+		}
+		if (type.equals(LocalDateTime.class)) {
+			DateTimeFormatter formatter = newDateTimeFormatter(bindingType, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+			return Optional.of(x -> LocalDateTime.parse(x, formatter));
+		}
+		if (type.equals(LocalDate.class)) {
+			DateTimeFormatter formatter = newDateTimeFormatter(bindingType, DateTimeFormatter.ISO_LOCAL_DATE);
+			return Optional.of(x -> LocalDate.parse(x, formatter));
+		}
+		if (type.equals(LocalTime.class)) {
+			DateTimeFormatter formatter = newDateTimeFormatter(bindingType, DateTimeFormatter.ISO_LOCAL_TIME);
+			return Optional.of(x -> LocalTime.parse(x, formatter));
+		}
+		if (type.equals(Date.class)) {
+			// a debatable default, but Date is anyway a lost cause...
+			DateTimeFormatter formatter = newDateTimeFormatter(bindingType, DateTimeFormatter.ISO_INSTANT);
+			return Optional.of(x -> Date.from(formatter.parse(x, Instant::from)));
 		}
 		return Optional.empty();
 	}
 
-	protected DateMapperInstance newDateMapperInstance(BindingType bindingType) {
-		return new DateMapperInstance(newOffsetDateTimeMapperInstance(bindingType));
-	}
-
-	protected OffsetDateTimeMapperInstance newOffsetDateTimeMapperInstance(BindingType bindingType) {
-		DateTime dateTime = bindingType.getBindingContext()
+	protected DateTimeFormatter newDateTimeFormatter(BindingType bindingType, DateTimeFormatter defaultFormatter) {
+		return bindingType.getBindingContext()
 				.getFactoryConfigFor(DateTimeMapper.class)
 				.filter(DateTime.class::isInstance)
 				.map(DateTime.class::cast)
-				.orElse(AnnonHolder.class.getAnnotation(DateTime.class));
-		final Locale formatLang = dateTime.lang()
-				.isEmpty() ? Locale.getDefault(Category.FORMAT) : Locale.forLanguageTag(dateTime.lang());
-		DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(dateTime.value(), formatLang);
-		return new OffsetDateTimeMapperInstance(dateTimeFormatter);
+				.map(annon -> {
+					DateTimeFormatter formatter =
+							annon.value().isEmpty() ? defaultFormatter : DateTimeFormatter.ofPattern(annon.value());
+					final Locale formatLang = annon.lang()
+							.isEmpty() ? Locale.getDefault(Category.FORMAT) : Locale.forLanguageTag(annon.lang());
+					return formatter.withLocale(formatLang);
+				}).orElse(defaultFormatter);
 	}
 }

--- a/confij-core/src/main/java/ch/kk7/confij/binding/values/DateTimeMapper.java
+++ b/confij-core/src/main/java/ch/kk7/confij/binding/values/DateTimeMapper.java
@@ -14,7 +14,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Locale;
-import java.util.Locale.Category;
 import java.util.Optional;
 
 import ch.kk7.confij.annotation.ValueMapper;
@@ -38,7 +37,7 @@ public class DateTimeMapper implements ValueMapperFactory {
 		/**
 		 * @return A locale string for {@link DateTimeFormatter#ofPattern(String, Locale)}
 		 */
-		String lang() default "";
+		String lang() default "us";
 	}
 
 	@Override
@@ -85,8 +84,7 @@ public class DateTimeMapper implements ValueMapperFactory {
 				.map(annon -> {
 					DateTimeFormatter formatter =
 							annon.value().isEmpty() ? defaultFormatter : DateTimeFormatter.ofPattern(annon.value());
-					final Locale formatLang = annon.lang()
-							.isEmpty() ? Locale.getDefault(Category.FORMAT) : Locale.forLanguageTag(annon.lang());
+					final Locale formatLang = Locale.forLanguageTag(annon.lang());
 					return formatter.withLocale(formatLang);
 				}).orElse(defaultFormatter);
 	}

--- a/confij-example/src/test/java/ch/kk7/confij/pipeline/MitAllesUndScharfTest.java
+++ b/confij-example/src/test/java/ch/kk7/confij/pipeline/MitAllesUndScharfTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
@@ -20,6 +21,7 @@ import java.util.SortedSet;
 import ch.kk7.confij.ConfijBuilder;
 import ch.kk7.confij.annotation.Default;
 import ch.kk7.confij.binding.values.Base64Mapper.Base64;
+import ch.kk7.confij.binding.values.DateTimeMapper.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -127,6 +129,9 @@ class MitAllesUndScharfTest {
 		@Default("10:15:30.01")
 		LocalTime localTime();
 
+		@Default("2001-12-14")
+		LocalDate localDate();
+
 		@Default("2001-12-14T21:59:43.01")
 		LocalDateTime localDateTime();
 
@@ -135,6 +140,10 @@ class MitAllesUndScharfTest {
 
 		@Default("2001-12-14T21:59:43.01+01:00[Europe/Paris]")
 		ZonedDateTime zonedDateTime();
+
+		@DateTime(value = "MMM-dd-uuuu")
+		@Default("Dec-14-2001")
+		LocalDate localDateWithFormat();
 	}
 
 	private MitAllesUndScharf instance;
@@ -196,9 +205,11 @@ class MitAllesUndScharfTest {
 			assertThat(dates.date()).isEqualTo("2001-12-14T21:59:43Z");
 			assertThat(dates.instant()).isEqualTo("2001-12-14T21:59:43.01Z");
 			assertThat(dates.localTime()).isEqualTo("10:15:30.01");
+			assertThat(dates.localDate()).isEqualTo("2001-12-14");
 			assertThat(dates.localDateTime()).isEqualTo("2001-12-14T21:59:43.01");
 			assertThat(dates.offsetDateTime()).isEqualTo("2001-12-14T21:59:43.01-05:00");
 			assertThat(dates.zonedDateTime()).isEqualTo("2001-12-14T21:59:43.01+01:00[Europe/Paris]");
+			assertThat(dates.localDateWithFormat()).isEqualTo("2001-12-14");
 		});
 	}
 }

--- a/confij-example/src/test/java/ch/kk7/confij/pipeline/MitAllesUndScharfTest.java
+++ b/confij-example/src/test/java/ch/kk7/confij/pipeline/MitAllesUndScharfTest.java
@@ -1,11 +1,15 @@
 package ch.kk7.confij.pipeline;
 
-import ch.kk7.confij.ConfijBuilder;
-import ch.kk7.confij.annotation.Default;
-import ch.kk7.confij.binding.values.Base64Mapper.Base64;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -13,8 +17,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import ch.kk7.confij.ConfijBuilder;
+import ch.kk7.confij.annotation.Default;
+import ch.kk7.confij.binding.values.Base64Mapper.Base64;
+import org.junit.jupiter.api.Test;
 
 public class MitAllesUndScharfTest {
 	public interface MitAllesUndScharf {
@@ -27,6 +33,8 @@ public class MitAllesUndScharfTest {
 		Maps maps();
 
 		Arrays arrays();
+
+		Dates dates();
 	}
 
 	public interface Primitives {
@@ -107,6 +115,27 @@ public class MitAllesUndScharfTest {
 		Primitives[] anInterfaceArray();
 	}
 
+	public interface Dates {
+
+		@Default("2001-12-14T21:59:43Z")
+		Date date();
+
+		@Default("2001-12-14T21:59:43.01Z")
+		Instant instant();
+
+		@Default("10:15:30.01")
+		LocalTime localTime();
+
+		@Default("2001-12-14T21:59:43.01")
+		LocalDateTime localDateTime();
+
+		@Default("2001-12-14T21:59:43.01-05:00")
+		OffsetDateTime offsetDateTime();
+
+		@Default("2001-12-14T21:59:43.01+01:00[Europe/Paris]")
+		ZonedDateTime zonedDateTime();
+	}
+
 	@Test
 	public void canInstantiateEmpty() {
 		MitAllesUndScharf allDefaults = ConfijBuilder.of(MitAllesUndScharf.class)
@@ -133,7 +162,7 @@ public class MitAllesUndScharfTest {
 		MitAllesUndScharf allDefaults = ConfijBuilder.of(MitAllesUndScharf.class)
 				.build();
 		Primitives primitives = allDefaults.primitives();
-//		assertThat(primitives.anInt()).isEqualTo(42);
+		assertThat(primitives.anInt()).isEqualTo(42);
 		assertThat(primitives.aLong()).isEqualTo(1337L);
 		assertThat(primitives.aByte()).isEqualTo((byte) 100);
 
@@ -147,11 +176,20 @@ public class MitAllesUndScharfTest {
 				.clear();
 
 		Maps maps = allDefaults.maps();
-//		assertThat(maps.mapStringString()).hasSize(1);
-//		assertThat(maps.mapStringString()).hasEntrySatisfying("key", value -> assertThat(value).isEqualTo("value" + maps.hashCode()));
+		assertThat(maps.mapStringString()).hasSize(1);
+		assertThat(maps.mapStringString()).hasEntrySatisfying("key", value -> assertThat(value).isEqualTo("value" + maps.hashCode()));
 
 		Arrays arrays = allDefaults.arrays();
-//		assertThat(arrays.aDefaultByteArray()).hasSize(3);
+		assertThat(arrays.aDefaultByteArray()).hasSize(3);
 		assertThat(arrays.aBase64ByteArray()).containsExactly(1,2,3);
+
+		assertThat(allDefaults.dates()).satisfies(dates -> {
+			assertThat(dates.date()).isEqualTo("2001-12-14T21:59:43Z");
+			assertThat(dates.instant()).isEqualTo("2001-12-14T21:59:43.01Z");
+			assertThat(dates.localTime()).isEqualTo("10:15:30.01");
+			assertThat(dates.localDateTime()).isEqualTo("2001-12-14T21:59:43.01");
+			assertThat(dates.offsetDateTime()).isEqualTo("2001-12-14T21:59:43.01-05:00");
+			assertThat(dates.zonedDateTime()).isEqualTo("2001-12-14T21:59:43.01+01:00[Europe/Paris]");
+		});
 	}
 }

--- a/confij-toml/src/main/java/ch/kk7/confij/source/format/TomlFormat.java
+++ b/confij-toml/src/main/java/ch/kk7/confij/source/format/TomlFormat.java
@@ -1,5 +1,17 @@
 package ch.kk7.confij.source.format;
 
+import static ch.kk7.confij.source.format.ConfijSourceFormatException.invalidFormat;
+import static java.util.stream.Collectors.joining;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
 import ch.kk7.confij.tree.ConfijNode;
 import com.google.auto.service.AutoService;
 import lombok.ToString;
@@ -9,25 +21,9 @@ import org.tomlj.TomlParseError;
 import org.tomlj.TomlParseResult;
 import org.tomlj.TomlTable;
 
-import java.net.URI;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
-
-import static ch.kk7.confij.source.format.ConfijSourceFormatException.invalidFormat;
-import static java.util.stream.Collectors.joining;
-
 @ToString
 @AutoService(ConfijSourceFormat.class)
 public class TomlFormat implements ConfijSourceFormat {
-
-	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SXXX");
 
 	@Override
 	public void override(ConfijNode rootNode, String content) {
@@ -77,15 +73,9 @@ public class TomlFormat implements ConfijSourceFormat {
 			return object;
 		}
 		if (object instanceof Long || object instanceof Double || object instanceof Boolean
-				|| object instanceof LocalDate || object instanceof LocalTime) {
+				|| object instanceof LocalDate || object instanceof LocalTime || object instanceof LocalDateTime ||
+				object instanceof OffsetDateTime) {
 			return object.toString();
-		}
-		if (object instanceof LocalDateTime) {
-			// Use system default zone id would be better.
-			return FORMATTER.withZone(ZoneId.systemDefault()).format((LocalDateTime) object);
-		}
-		if (object instanceof OffsetDateTime) {
-			return FORMATTER.format((OffsetDateTime) object);
 		}
 		if (object instanceof TomlTable) {
 			return transformTomlTable((TomlTable) object);

--- a/confij-yaml/src/test/java/ch/kk7/confij/source/format/YamlFormatTest.java
+++ b/confij-yaml/src/test/java/ch/kk7/confij/source/format/YamlFormatTest.java
@@ -1,13 +1,15 @@
 package ch.kk7.confij.source.format;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZoneId;
+import java.util.Map;
+import java.util.TimeZone;
+
 import ch.kk7.confij.ConfijBuilder;
 import ch.kk7.confij.common.GenericType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class YamlFormatTest {
 	private static Map<String, Map<String, String>> types;
@@ -47,8 +49,15 @@ class YamlFormatTest {
 	public void dates() {
 		Map<String, String> dates = types.get("dates");
 		assertThat(dates.get("canonical")).isEqualTo("2001-12-15T02:59:43.1Z");
-		assertThat(dates.get("iso8601")).isEqualTo("2001-12-15T02:59:43.1Z");
-		assertThat(dates.get("space")).isEqualTo("2001-12-15T02:59:43.1Z");
+		assertThat(dates.get("iso8601")).isEqualTo("2001-12-14T21:59:43.1-05:00");
+		assertThat(dates.get("space")).isEqualTo("2001-12-14T21:59:43.1-05:00");
+		assertThat(dates.get("date")).isEqualTo("2002-12-14T00:00:00Z");
+	}
+
+	@Test
+	public void datesAtDifferentLocalTz() {
+		runWithSystemTimezone(TimeZone.getTimeZone(ZoneId.of("CET")), this::dates);
+		runWithSystemTimezone(TimeZone.getTimeZone(ZoneId.of("UTC")), this::dates);
 	}
 
 	@Test
@@ -68,5 +77,15 @@ class YamlFormatTest {
 		assertThat(multidoc.x()).isEqualTo(1);
 		assertThat(multidoc.y()).isEqualTo(2);
 		assertThat(multidoc.z()).isEqualTo(2);
+	}
+
+	private static void runWithSystemTimezone(TimeZone timeZone, Runnable test) {
+		final TimeZone original = TimeZone.getDefault();
+		try {
+			TimeZone.setDefault(timeZone);
+			test.run();
+		} finally {
+			TimeZone.setDefault(original);
+		}
 	}
 }

--- a/confij-yaml/src/test/java/ch/kk7/confij/source/format/YamlFormatTest.java
+++ b/confij-yaml/src/test/java/ch/kk7/confij/source/format/YamlFormatTest.java
@@ -31,46 +31,45 @@ class YamlFormatTest {
 	}
 
 	@Test
-	public void integers() {
+	void integers() {
 		assertThat(types.get("integers")
 				.values()).allSatisfy(s -> assertThat(s).isEqualTo("12345"));
 	}
 
 	@Test
-	public void floats() {
-		Map<String, String> floats = types.get("floats");
-		assertThat(floats.get("exponential")).isEqualTo("1230.15");
-		assertThat(floats.get("fixed")).isEqualTo("1230.15");
-		assertThat(floats.get("infinite negative")).isEqualTo("-Infinity");
-		assertThat(floats.get("not a number")).isEqualTo("NaN");
+	void floats() {
+		assertThat(types.get("floats"))
+				.containsEntry("exponential", "1230.15")
+				.containsEntry("fixed", "1230.15")
+				.containsEntry("infinite negative", "-Infinity")
+				.containsEntry("not a number", "NaN");
 	}
 
 	@Test
-	public void dates() {
-		Map<String, String> dates = types.get("dates");
-		assertThat(dates.get("canonical")).isEqualTo("2001-12-15T02:59:43.1Z");
-		assertThat(dates.get("iso8601")).isEqualTo("2001-12-14T21:59:43.1-05:00");
-		assertThat(dates.get("space")).isEqualTo("2001-12-14T21:59:43.1-05:00");
-		assertThat(dates.get("date")).isEqualTo("2002-12-14T00:00:00Z");
+	void dates() {
+		assertThat(types.get("dates")).containsEntry("canonical", "2001-12-15T02:59:43.1Z")
+				.containsEntry("iso8601", "2001-12-14T21:59:43.1-05:00")
+				.containsEntry("space", "2001-12-14T21:59:43.1-05:00")
+				.containsEntry("date", "2002-12-14T00:00:00Z");
 	}
 
 	@Test
-	public void datesAtDifferentLocalTz() {
+	void datesAtDifferentLocalTz() {
 		runWithSystemTimezone(TimeZone.getTimeZone(ZoneId.of("CET")), this::dates);
 		runWithSystemTimezone(TimeZone.getTimeZone(ZoneId.of("UTC")), this::dates);
 	}
 
 	@Test
-	public void miscellaneous() {
-		Map<String, String> miscellaneous = types.get("miscellaneous");
-		assertThat(miscellaneous.get("null")).isEqualTo(null);
-		assertThat(miscellaneous.get("null bis")).isEqualTo(null);
-		assertThat(miscellaneous.get("true ter")).isEqualTo("true");
-		assertThat(miscellaneous.get("false bis")).isEqualTo("false");
+	void miscellaneous() {
+		assertThat(types.get("miscellaneous"))
+				.containsEntry("null", null)
+				.containsEntry("null bis", null)
+				.containsEntry("true ter", "true")
+				.containsEntry("false bis", "false");
 	}
 
 	@Test
-	public void multidoc() {
+	void multidoc() {
 		Multidoc multidoc = ConfijBuilder.of(Multidoc.class)
 				.loadFrom("classpath:multidoc.yml")
 				.build();


### PR DESCRIPTION
Support for all common temporal types like ZonedDateTime, OffsetDateTime, LocalDateTime,... and (sadly) Date. The default format assumed is always the corresponding ISO-8601 format (for Instant this means UTC). Every temporal type format can be modified using `@DateTime` however.
Additionally added a fix for yaml dates, such that the time offset is not forgotten. Toml already does it right and is internally converted to iso types, too (in order to not depend on system time).

Minor: better reproducibility of gradle builds by failing on version conflicts and preventing versions like +.
Minor: ignore sonar report on PRs from forks (as they do not have access to the token).