### PR TITLE
glob expressions in paths

### DIFF
--- a/confij-core/src/main/java/ch/kk7/confij/source/ConfijSourceBuilder.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/ConfijSourceBuilder.java
@@ -1,8 +1,55 @@
 package ch.kk7.confij.source;
 
+import lombok.NonNull;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.Optional;
 
 public interface ConfijSourceBuilder {
-	Optional<ConfijSource> fromURI(URI path);
+	Optional<ConfijSource> fromURI(URIish path);
+
+	@Value
+	@NonFinal
+	class URIish {
+		String scheme;
+
+		@NonNull String schemeSpecificPart;
+
+		String fragment;
+
+		public static URIish create(@NonNull String uri) {
+			final String scheme;
+			String path;
+			final String fragment;
+			String[] schemeParts = uri.split(":", 2);
+			if (schemeParts.length == 1) {
+				scheme = null;
+				path = schemeParts[0];
+			} else {
+				scheme = schemeParts[0];
+				path = schemeParts[1];
+			}
+			String[] pathParts = path.split("#", 2);
+			if (pathParts.length == 1) {
+				fragment = null;
+			} else {
+				path = pathParts[0];
+				fragment = pathParts[1];
+			}
+			return new URIish(scheme, path, fragment);
+		}
+
+		public URL toURL() throws MalformedURLException {
+			try {
+				return new URI(scheme, schemeSpecificPart, fragment).toURL();
+			} catch (URISyntaxException e) {
+				throw new MalformedURLException(e.getMessage());
+			}
+		}
+	}
 }

--- a/confij-core/src/main/java/ch/kk7/confij/source/any/AnyResourceBuilder.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/any/AnyResourceBuilder.java
@@ -8,7 +8,6 @@ import ch.kk7.confij.source.resource.ConfijResourceProvider;
 import com.google.auto.service.AutoService;
 import lombok.ToString;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,7 +29,7 @@ public class AnyResourceBuilder implements ConfijSourceBuilder {
 	}
 
 	@Override
-	public Optional<ConfijSource> fromURI(URI path) {
+	public Optional<ConfijSource> fromURI(URIish path) {
 		Optional<ConfijResourceProvider> resource = supportedResources.stream()
 				.filter(r -> r.canHandle(path))
 				.findFirst();

--- a/confij-core/src/main/java/ch/kk7/confij/source/any/AnySource.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/any/AnySource.java
@@ -3,14 +3,13 @@ package ch.kk7.confij.source.any;
 import ch.kk7.confij.common.ServiceLoaderUtil;
 import ch.kk7.confij.source.ConfijSource;
 import ch.kk7.confij.source.ConfijSourceBuilder;
+import ch.kk7.confij.source.ConfijSourceBuilder.URIish;
 import ch.kk7.confij.source.ConfijSourceException;
 import ch.kk7.confij.template.ValueResolver;
 import ch.kk7.confij.tree.ConfijNode;
 import lombok.Data;
 import lombok.ToString;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -39,37 +38,14 @@ public class AnySource implements ConfijSource {
 				.getValueResolver();
 	}
 
-	protected URI resolveUri(ConfijNode rootNode) {
+	protected URIish resolveUri(ConfijNode rootNode) {
 		String actualPath = getResolver(rootNode).resolveValue(rootNode, pathTemplate);
-		// this part is a workaround to escape the URI instead of new URI(actualPath)
-		final String scheme;
-		String path;
-		final String fragment;
-		String[] schemeParts = actualPath.split(":", 2);
-		if (schemeParts.length == 1) {
-			scheme = null;
-			path = schemeParts[0];
-		} else {
-			scheme = schemeParts[0];
-			path = schemeParts[1];
-		}
-		String[] pathParts = path.split("#", 2);
-		if (pathParts.length == 1) {
-			fragment = null;
-		} else {
-			path = pathParts[0];
-			fragment = pathParts[1];
-		}
-		try {
-			return new URI(scheme, path, fragment);
-		} catch (URISyntaxException e) {
-			throw new ConfijSourceException("The {} failed to resolve the path-template '{}' into a valid URI", this, pathTemplate, e);
-		}
+		return URIish.create(actualPath);
 	}
 
 	@Override
 	public void override(ConfijNode rootNode) {
-		URI path = resolveUri(rootNode);
+		URIish path = resolveUri(rootNode);
 		ConfijSource confijSource = sourceBuilders.stream()
 				.map(sourceBulder -> sourceBulder.fromURI(path))
 				.filter(Optional::isPresent)

--- a/confij-core/src/main/java/ch/kk7/confij/source/any/FixedResourceSource.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/any/FixedResourceSource.java
@@ -2,6 +2,7 @@ package ch.kk7.confij.source.any;
 
 import ch.kk7.confij.logging.ConfijLogger;
 import ch.kk7.confij.source.ConfijSource;
+import ch.kk7.confij.source.ConfijSourceBuilder;
 import ch.kk7.confij.source.ConfijSourceException;
 import ch.kk7.confij.source.format.ConfijSourceFormat;
 import ch.kk7.confij.source.format.ConfijSourceFormatException;
@@ -12,7 +13,6 @@ import lombok.NonNull;
 import lombok.Value;
 import lombok.experimental.NonFinal;
 
-import java.net.URI;
 import java.util.stream.Stream;
 
 /**
@@ -25,7 +25,7 @@ import java.util.stream.Stream;
 public class FixedResourceSource implements ConfijSource {
 	private static final ConfijLogger LOGGER = ConfijLogger.getLogger(FixedResourceSource.class);
 
-	@NonNull URI path;
+	@NonNull ConfijSourceBuilder.URIish path;
 	@NonNull ConfijResourceProvider resource;
 	@NonNull ConfijSourceFormat format;
 

--- a/confij-core/src/main/java/ch/kk7/confij/source/env/EnvvarSource.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/env/EnvvarSource.java
@@ -6,7 +6,6 @@ import ch.kk7.confij.source.format.PropertiesFormat;
 import ch.kk7.confij.tree.ConfijNode;
 import com.google.auto.service.AutoService;
 
-import java.net.URI;
 import java.util.Optional;
 
 @AutoService(ConfijSourceBuilder.class)
@@ -29,7 +28,7 @@ public class EnvvarSource extends PropertiesFormat implements ConfijSource, Conf
 	}
 
 	@Override
-	public Optional<ConfijSource> fromURI(URI path) {
+	public Optional<ConfijSource> fromURI(URIish path) {
 		if (SCHEME.equals(path.getScheme())) {
 			EnvvarSource source = new EnvvarSource();
 			source.setGlobalPrefix(path.getSchemeSpecificPart());

--- a/confij-core/src/main/java/ch/kk7/confij/source/env/SystemPropertiesSource.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/env/SystemPropertiesSource.java
@@ -4,7 +4,6 @@ import ch.kk7.confij.source.ConfijSource;
 import ch.kk7.confij.source.ConfijSourceBuilder;
 import com.google.auto.service.AutoService;
 
-import java.net.URI;
 import java.util.Optional;
 
 @AutoService(ConfijSourceBuilder.class)
@@ -16,7 +15,7 @@ public class SystemPropertiesSource extends PropertiesSource implements ConfijSo
 	}
 
 	@Override
-	public Optional<ConfijSource> fromURI(URI path) {
+	public Optional<ConfijSource> fromURI(URIish path) {
 		if (SCHEME.equals(path.getScheme())) {
 			SystemPropertiesSource source = new SystemPropertiesSource();
 			source.setGlobalPrefix(path.getSchemeSpecificPart());

--- a/confij-core/src/main/java/ch/kk7/confij/source/format/ConfijSourceFormat.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/format/ConfijSourceFormat.java
@@ -1,11 +1,10 @@
 package ch.kk7.confij.source.format;
 
+import ch.kk7.confij.source.ConfijSourceBuilder.URIish;
 import ch.kk7.confij.tree.ConfijNode;
-
-import java.net.URI;
 
 public interface ConfijSourceFormat {
 	void override(ConfijNode rootNode, String configAsStr);
 
-	boolean canHandle(URI path);
+	boolean canHandle(URIish path);
 }

--- a/confij-core/src/main/java/ch/kk7/confij/source/format/PropertiesFormat.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/format/PropertiesFormat.java
@@ -1,5 +1,6 @@
 package ch.kk7.confij.source.format;
 
+import ch.kk7.confij.source.ConfijSourceBuilder.URIish;
 import ch.kk7.confij.tree.ConfijNode;
 import com.google.auto.service.AutoService;
 import lombok.Getter;
@@ -8,7 +9,6 @@ import lombok.Setter;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -118,7 +118,7 @@ public class PropertiesFormat implements ConfijSourceFormat {
 	}
 
 	@Override
-	public boolean canHandle(URI path) {
+	public boolean canHandle(URIish path) {
 		return path.getSchemeSpecificPart()
 				.matches("(?s).+\\.prop(ertie)?s?$");
 	}

--- a/confij-core/src/main/java/ch/kk7/confij/source/resource/ClasspathResourceProvider.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/resource/ClasspathResourceProvider.java
@@ -1,9 +1,9 @@
 package ch.kk7.confij.source.resource;
 
+import ch.kk7.confij.source.ConfijSourceBuilder.URIish;
 import com.google.auto.service.AutoService;
 import lombok.ToString;
 
-import java.net.URI;
 import java.net.URL;
 import java.util.stream.Stream;
 
@@ -15,7 +15,7 @@ public class ClasspathResourceProvider extends URLResourceProvider {
 	public static final String SCHEME = "classpath";
 
 	@Override
-	public Stream<String> read(URI path) {
+	public Stream<String> read(URIish path) {
 		URL classpathUrl = ClassLoader.getSystemResource(path.getSchemeSpecificPart());
 		if (classpathUrl == null) {
 			// TODO: print suggestions of alternative resources (on same path, or with same name, or / instead of dot...)
@@ -25,7 +25,7 @@ public class ClasspathResourceProvider extends URLResourceProvider {
 	}
 
 	@Override
-	public boolean canHandle(URI path) {
+	public boolean canHandle(URIish path) {
 		return SCHEME.equals(path.getScheme());
 	}
 }

--- a/confij-core/src/main/java/ch/kk7/confij/source/resource/ClasspathResourceProvider.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/resource/ClasspathResourceProvider.java
@@ -5,6 +5,7 @@ import lombok.ToString;
 
 import java.net.URI;
 import java.net.URL;
+import java.util.stream.Stream;
 
 import static ch.kk7.confij.source.resource.ConfijSourceFetchingException.unableToFetch;
 
@@ -14,13 +15,13 @@ public class ClasspathResourceProvider extends URLResourceProvider {
 	public static final String SCHEME = "classpath";
 
 	@Override
-	public String read(URI path) {
+	public Stream<String> read(URI path) {
 		URL classpathUrl = ClassLoader.getSystemResource(path.getSchemeSpecificPart());
 		if (classpathUrl == null) {
 			// TODO: print suggestions of alternative resources (on same path, or with same name, or / instead of dot...)
 			throw unableToFetch(path.getSchemeSpecificPart(), "no such file on system classpath");
 		}
-		return read(classpathUrl);
+		return Stream.of(read(classpathUrl));
 	}
 
 	@Override

--- a/confij-core/src/main/java/ch/kk7/confij/source/resource/ConfijResourceProvider.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/resource/ConfijResourceProvider.java
@@ -1,6 +1,7 @@
 package ch.kk7.confij.source.resource;
 
 import java.net.URI;
+import java.util.stream.Stream;
 
 /**
  * A resource provider basically reads a string from anywhere given an URI.<br/>
@@ -15,7 +16,7 @@ public interface ConfijResourceProvider {
 	 * @param path the URI to read from
 	 * @return the string representation of the path's content
 	 */
-	String read(URI path);
+	Stream<String> read(URI path);
 
 	/**
 	 * Receive a "preview" on the URI to be processed. This resouce provider can choose to accept or reject processing it.

--- a/confij-core/src/main/java/ch/kk7/confij/source/resource/ConfijResourceProvider.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/resource/ConfijResourceProvider.java
@@ -1,6 +1,7 @@
 package ch.kk7.confij.source.resource;
 
-import java.net.URI;
+import ch.kk7.confij.source.ConfijSourceBuilder.URIish;
+
 import java.util.stream.Stream;
 
 /**
@@ -16,7 +17,7 @@ public interface ConfijResourceProvider {
 	 * @param path the URI to read from
 	 * @return the string representation of the path's content
 	 */
-	Stream<String> read(URI path);
+	Stream<String> read(URIish path);
 
 	/**
 	 * Receive a "preview" on the URI to be processed. This resouce provider can choose to accept or reject processing it.
@@ -25,5 +26,5 @@ public interface ConfijResourceProvider {
 	 * @param path an URI to be processed later.
 	 * @return true if this resouce provider accepts processing this URI (but it can still fail)
 	 */
-	boolean canHandle(URI path);
+	boolean canHandle(URIish path);
 }

--- a/confij-core/src/main/java/ch/kk7/confij/source/resource/ConfijSourceFetchingException.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/resource/ConfijSourceFetchingException.java
@@ -8,6 +8,6 @@ public class ConfijSourceFetchingException extends ConfijSourceException {
 	}
 
 	public static ConfijSourceFetchingException unableToFetch(String path, String detail, Object... args) {
-		return new ConfijSourceFetchingException("unable to read configuration from '" + path + "', " + detail, args);
+		return new ConfijSourceFetchingException("unable to read configuration from '{}', " + detail, path, args);
 	}
 }

--- a/confij-core/src/main/java/ch/kk7/confij/source/resource/FileResourceProvider.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/resource/FileResourceProvider.java
@@ -1,17 +1,20 @@
 package ch.kk7.confij.source.resource;
 
 import ch.kk7.confij.logging.ConfijLogger;
+import ch.kk7.confij.source.ConfijSourceBuilder.URIish;
 import com.google.auto.service.AutoService;
 import lombok.NonNull;
+import lombok.Setter;
 import lombok.SneakyThrows;
 import lombok.ToString;
 import lombok.Value;
+import lombok.experimental.FieldNameConstants;
 import lombok.experimental.NonFinal;
 
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URL;
 import java.nio.file.FileSystems;
+import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -21,6 +24,8 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -29,73 +34,95 @@ import java.util.stream.Stream;
 import static ch.kk7.confij.source.resource.ConfijSourceFetchingException.unableToFetch;
 
 @ToString
+@Setter
+@FieldNameConstants
 @AutoService(ConfijResourceProvider.class)
 public class FileResourceProvider extends URLResourceProvider {
-	private static final ConfijLogger LOGGER = ConfijLogger.getLogger(FileResourceProvider.class);
-
 	public static final String SCHEME = "file";
 
-	int maxFileMatches = 100;
+	private static final ConfijLogger LOGGER = ConfijLogger.getLogger(FileResourceProvider.class);
 
-	int warnFilesTraversed = 1000;
+	int maxFileMatches = 50;
+
+	int maxFilesTraversed = 10000;
 
 	Pattern globPattern = Pattern.compile("(^|.*[^\\\\])([*?]|\\[.+]|\\{.+}).*");
 
+	@Value
+	@NonFinal
+	protected static class PathAndMatcher {
+		Path basePath;
+
+		PathMatcher pathMatcher;
+
+		String originalPath;
+
+		int maxDepth;
+	}
+
 	@SneakyThrows
-	protected List<Path> getFilesMatching(@NonNull Path basePath, @NonNull PathMatcher pathMatcher, String originalPath) {
+	protected List<Path> getFilesMatching(@NonNull PathAndMatcher query) {
 		List<Path> matchingFiles = new ArrayList<>();
 		final int[] fileCounter = new int[]{0};
-		Files.walkFileTree(basePath, new SimpleFileVisitor<Path>() {
+		// TODO: configurable symlink follow
+		Files.walkFileTree(query.getBasePath(), EnumSet.noneOf(FileVisitOption.class), query.getMaxDepth(), new SimpleFileVisitor<Path>() {
 			@Override
 			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-				if (pathMatcher.matches(file)) {
+				if (query.getPathMatcher()
+						.matches(file)) {
 					if (matchingFiles.size() >= maxFileMatches) {
 						throw new ConfijSourceFetchingException("found too many files (>={}) matching glob expression. " +
-								"your expression '{}' seems too lax.", maxFileMatches, originalPath);
+								"your expression '{}' seems too lax. if this was intentional, try to increase '{}'", maxFileMatches,
+								query.getOriginalPath(), Fields.maxFileMatches);
+					}
+					if (++fileCounter[0] >= maxFilesTraversed) {
+						throw new ConfijSourceFetchingException("traversed too many files (>={}) in query of a maching glob expression. " +
+								"your expression '{}' seems too expensive. if this was intentional, try to increase '{}'", fileCounter[0],
+								query.getOriginalPath(), Fields.maxFilesTraversed);
 					}
 					matchingFiles.add(file);
-					fileCounter[0]++;
 				}
 				return FileVisitResult.CONTINUE;
 			}
 		});
-		if (fileCounter[0] >= warnFilesTraversed) {
-			LOGGER.info("traversed {} files to get {} files matching glob {}: that was an expensive operation", fileCounter[0],
-					matchingFiles.size(), originalPath);
-		}
-		Collections.sort(matchingFiles);
+		LOGGER.debug("traversed {} files to find {} files matching glob '{}'", fileCounter[0], matchingFiles.size(),
+				query.getOriginalPath());
+		matchingFiles.sort(Comparator.comparingInt(Path::getNameCount)
+				.thenComparing(Comparator.naturalOrder()));
 		return matchingFiles;
-	}
-
-	@Value
-	@NonFinal
-	private static class PathAndMatcher {
-		Path basePath;
-		PathMatcher pathMatcher;
 	}
 
 	protected PathAndMatcher extractGlob(String path) {
 		String[] parts = path.split("/", -1);
 		int globAt = -1;
+		int maxDepth = -1;
 		for (int i = 0; i < parts.length; i++) {
-			if (globPattern.matcher(parts[i])
-					.matches()) {
-				globAt = i;
-				break;
+			if (globAt == -1) { // still searching for first glob
+				if (globPattern.matcher(parts[i])
+						.matches()) {
+					globAt = i;
+					maxDepth = 0;
+				}
+			}
+			if (globAt != -1) { // already found first glob
+				if (parts[i].contains("**")) {
+					maxDepth = Integer.MAX_VALUE;
+					break;
+				} else {
+					maxDepth++;
+				}
 			}
 		}
 		if (globAt == -1) {
-			return new PathAndMatcher(Paths.get(path), null);
+			return new PathAndMatcher(Paths.get(path), null, path, -1);
 		}
 		String beforeGlob = Stream.of(parts)
 				.limit(globAt)
 				.collect(Collectors.joining("/"));
-		String globExpression = Stream.of(parts)
-				.skip(globAt)
-				.collect(Collectors.joining("/"));
 		// TODO: support other pathMatchers like regex
-		final PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher("glob:" + globExpression);
-		return new PathAndMatcher(Paths.get(beforeGlob), pathMatcher);
+		final PathMatcher pathMatcher = FileSystems.getDefault()
+				.getPathMatcher("glob:" + path);
+		return new PathAndMatcher(Paths.get(beforeGlob), pathMatcher, path, maxDepth);
 	}
 
 	protected String read(Path path) {
@@ -111,7 +138,7 @@ public class FileResourceProvider extends URLResourceProvider {
 	}
 
 	@Override
-	public Stream<String> read(URI fileUri) {
+	public Stream<String> read(URIish fileUri) {
 		String path = fileUri.getSchemeSpecificPart();
 		PathAndMatcher query = extractGlob(path);
 
@@ -119,14 +146,14 @@ public class FileResourceProvider extends URLResourceProvider {
 		if (query.getPathMatcher() == null) { // a file must exist if not a glob
 			matchingFiles = Collections.singletonList(query.getBasePath());
 		} else {
-			matchingFiles = getFilesMatching(query.getBasePath(), query.getPathMatcher(), path);
+			matchingFiles = getFilesMatching(query);
 		}
 		return matchingFiles.stream()
 				.map(this::read);
 	}
 
 	@Override
-	public boolean canHandle(URI path) {
-		return !path.isAbsolute() || SCHEME.equals(path.getScheme());
+	public boolean canHandle(URIish path) {
+		return path.getScheme() == null || SCHEME.equals(path.getScheme());
 	}
 }

--- a/confij-core/src/main/java/ch/kk7/confij/source/resource/FileResourceProvider.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/resource/FileResourceProvider.java
@@ -1,45 +1,128 @@
 package ch.kk7.confij.source.resource;
 
+import ch.kk7.confij.logging.ConfijLogger;
 import com.google.auto.service.AutoService;
+import lombok.NonNull;
+import lombok.SneakyThrows;
 import lombok.ToString;
+import lombok.Value;
+import lombok.experimental.NonFinal;
 
-import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static ch.kk7.confij.source.resource.ConfijSourceFetchingException.unableToFetch;
 
 @ToString
 @AutoService(ConfijResourceProvider.class)
 public class FileResourceProvider extends URLResourceProvider {
+	private static final ConfijLogger LOGGER = ConfijLogger.getLogger(FileResourceProvider.class);
+
 	public static final String SCHEME = "file";
 
-	@Override
-	public String read(URI fileUri) {
-		String path = fileUri.getSchemeSpecificPart();
-		final File file;
+	int maxFileMatches = 100;
+
+	int warnFilesTraversed = 1000;
+
+	Pattern globPattern = Pattern.compile("(^|.*[^\\\\])([*?]|\\[.+]|\\{.+}).*");
+
+	@SneakyThrows
+	protected List<Path> getFilesMatching(@NonNull Path basePath, @NonNull PathMatcher pathMatcher, String originalPath) {
+		List<Path> matchingFiles = new ArrayList<>();
+		final int[] fileCounter = new int[]{0};
+		Files.walkFileTree(basePath, new SimpleFileVisitor<Path>() {
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+				if (pathMatcher.matches(file)) {
+					if (matchingFiles.size() >= maxFileMatches) {
+						throw new ConfijSourceFetchingException("found too many files (>={}) matching glob expression. " +
+								"your expression '{}' seems too lax.", maxFileMatches, originalPath);
+					}
+					matchingFiles.add(file);
+					fileCounter[0]++;
+				}
+				return FileVisitResult.CONTINUE;
+			}
+		});
+		if (fileCounter[0] >= warnFilesTraversed) {
+			LOGGER.info("traversed {} files to get {} files matching glob {}: that was an expensive operation", fileCounter[0],
+					matchingFiles.size(), originalPath);
+		}
+		Collections.sort(matchingFiles);
+		return matchingFiles;
+	}
+
+	@Value
+	@NonFinal
+	private static class PathAndMatcher {
+		Path basePath;
+		PathMatcher pathMatcher;
+	}
+
+	protected PathAndMatcher extractGlob(String path) {
+		String[] parts = path.split("/", -1);
+		int globAt = -1;
+		for (int i = 0; i < parts.length; i++) {
+			if (globPattern.matcher(parts[i])
+					.matches()) {
+				globAt = i;
+				break;
+			}
+		}
+		if (globAt == -1) {
+			return new PathAndMatcher(Paths.get(path), null);
+		}
+		String beforeGlob = Stream.of(parts)
+				.limit(globAt)
+				.collect(Collectors.joining("/"));
+		String globExpression = Stream.of(parts)
+				.skip(globAt)
+				.collect(Collectors.joining("/"));
+		// TODO: support other pathMatchers like regex
+		final PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher("glob:" + globExpression);
+		return new PathAndMatcher(Paths.get(beforeGlob), pathMatcher);
+	}
+
+	protected String read(Path path) {
+		URL url;
 		try {
-			file = Paths.get(path)
-					.toFile();
-		} catch (Exception e) {
-			throw unableToFetch(path, "not a valid path");
-		}
-		if (!file.exists()) {
-			throw unableToFetch(file.getAbsolutePath(), "file does not exist");
-		}
-		if (!file.isFile()) {
-			throw unableToFetch(file.getAbsolutePath(), "not a file");
-		}
-		if (!file.canRead()) {
-			throw unableToFetch(file.getAbsolutePath(), "cannot read file");
-		}
-		try {
-			return read(file.toURI()
-					.toURL());
+			url = path.toUri()
+					.toURL();
 		} catch (MalformedURLException e) {
-			throw unableToFetch(file.getAbsolutePath(), "not a valid URL", e);
+			throw unableToFetch(path.toAbsolutePath()
+					.toString(), "not a valid URL", e);
 		}
+		return read(url);
+	}
+
+	@Override
+	public Stream<String> read(URI fileUri) {
+		String path = fileUri.getSchemeSpecificPart();
+		PathAndMatcher query = extractGlob(path);
+
+		List<Path> matchingFiles;
+		if (query.getPathMatcher() == null) { // a file must exist if not a glob
+			matchingFiles = Collections.singletonList(query.getBasePath());
+		} else {
+			matchingFiles = getFilesMatching(query.getBasePath(), query.getPathMatcher(), path);
+		}
+		return matchingFiles.stream()
+				.map(this::read);
 	}
 
 	@Override

--- a/confij-core/src/main/java/ch/kk7/confij/source/resource/URLResourceProvider.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/resource/URLResourceProvider.java
@@ -1,12 +1,12 @@
 package ch.kk7.confij.source.resource;
 
+import ch.kk7.confij.source.ConfijSourceBuilder.URIish;
 import com.google.auto.service.AutoService;
 import lombok.ToString;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URL;
 import java.util.Scanner;
 import java.util.stream.Stream;
@@ -17,7 +17,7 @@ import static ch.kk7.confij.source.resource.ConfijSourceFetchingException.unable
 @AutoService(ConfijResourceProvider.class)
 public class URLResourceProvider extends AbstractResourceProvider {
 	@Override
-	public Stream<String> read(URI path) {
+	public Stream<String> read(URIish path) {
 		try {
 			return Stream.of(read(path.toURL()));
 		} catch (MalformedURLException e) {
@@ -27,17 +27,16 @@ public class URLResourceProvider extends AbstractResourceProvider {
 
 	String read(URL url) {
 		try (InputStream inputStream = url.openStream()) {
-			return new Scanner(inputStream, getCharset().name()).useDelimiter("\\A")
-					.next();
+			Scanner s = new Scanner(inputStream, getCharset().name()).useDelimiter("\\A");
+			return s.hasNext() ? s.next() : "";
 		} catch (IOException e) {
 			throw unableToFetch(url.toString(), "cannot read", e);
 		}
 	}
 
 	@Override
-	public boolean canHandle(URI path) {
+	public boolean canHandle(URIish path) {
 		try {
-			//noinspection ResultOfMethodCallIgnored
 			path.toURL();
 		} catch (MalformedURLException e) {
 			return false;

--- a/confij-core/src/main/java/ch/kk7/confij/source/resource/URLResourceProvider.java
+++ b/confij-core/src/main/java/ch/kk7/confij/source/resource/URLResourceProvider.java
@@ -9,6 +9,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.util.Scanner;
+import java.util.stream.Stream;
 
 import static ch.kk7.confij.source.resource.ConfijSourceFetchingException.unableToFetch;
 
@@ -16,9 +17,9 @@ import static ch.kk7.confij.source.resource.ConfijSourceFetchingException.unable
 @AutoService(ConfijResourceProvider.class)
 public class URLResourceProvider extends AbstractResourceProvider {
 	@Override
-	public String read(URI path) {
+	public Stream<String> read(URI path) {
 		try {
-			return read(path.toURL());
+			return Stream.of(read(path.toURL()));
 		} catch (MalformedURLException e) {
 			throw unableToFetch(path.toString(), "not a valid URL", e);
 		}
@@ -29,7 +30,7 @@ public class URLResourceProvider extends AbstractResourceProvider {
 			return new Scanner(inputStream, getCharset().name()).useDelimiter("\\A")
 					.next();
 		} catch (IOException e) {
-			throw unableToFetch(url.toString(), "cannot read input stream", e);
+			throw unableToFetch(url.toString(), "cannot read", e);
 		}
 	}
 

--- a/confij-core/src/test/java/ch/kk7/confij/source/resource/FileResourceProviderGlobTest.java
+++ b/confij-core/src/test/java/ch/kk7/confij/source/resource/FileResourceProviderGlobTest.java
@@ -1,0 +1,56 @@
+package ch.kk7.confij.source.resource;
+
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Paths;
+
+class FileResourceProviderGlobTest implements WithAssertions {
+	private FileResourceProvider provider;
+
+	@BeforeEach
+	public void init() {
+		provider = new FileResourceProvider();
+	}
+
+	@Test
+	public void oneGlob() {
+		assertThat(provider.extractGlob("/fuu/bar/a*.txt")).satisfies(x -> {
+			assertThat(x.getBasePath()).isEqualTo(Paths.get("/fuu/bar"));
+			assertThat(x.getMaxDepth()).isEqualTo(1);
+			assertThat(x.getPathMatcher()
+					.matches(Paths.get("/fuu/bar/abc.txt"))).isTrue();
+			assertThat(x.getPathMatcher()
+					.matches(Paths.get("/fuu/bar/a.txt"))).isTrue();
+			assertThat(x.getPathMatcher()
+					.matches(Paths.get("/fuu/bar/b.txt"))).isFalse();
+			assertThat(x.getPathMatcher()
+					.matches(Paths.get("a.txt"))).isFalse();
+		});
+	}
+
+	@Test
+	public void globAtRoot() {
+		assertThat(provider.extractGlob("x**.txt")).satisfies(x -> {
+			assertThat(x.getBasePath()).isEqualTo(Paths.get(""));
+		});
+	}
+
+	@Test
+	public void escapedGlob() {
+		assertThat(provider.extractGlob("fuu/BA\\*")).satisfies(x -> {
+			assertThat(x.getBasePath()).isEqualTo(Paths.get("fuu/BA\\*"));
+		});
+	}
+
+	@Test
+	public void multiGlob() {
+		assertThat(provider.extractGlob("fuu/**/xxx/?.x")).satisfies(x -> {
+			assertThat(x.getBasePath()).isEqualTo(Paths.get("fuu"));
+			assertThat(x.getPathMatcher()
+					.matches(Paths.get("fuu/a/b/c/d/e/xxx/xxx/f.x"))).isTrue();
+			assertThat(x.getMaxDepth()).isEqualTo(Integer.MAX_VALUE);
+		});
+	}
+}

--- a/confij-core/src/test/java/ch/kk7/confij/source/resource/FileResourceProviderTest.java
+++ b/confij-core/src/test/java/ch/kk7/confij/source/resource/FileResourceProviderTest.java
@@ -1,0 +1,75 @@
+package ch.kk7.confij.source.resource;
+
+import ch.kk7.confij.source.ConfijSourceBuilder.URIish;
+import ch.kk7.confij.source.ConfijSourceException;
+import org.assertj.core.api.ListAssert;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+class FileResourceProviderTest implements WithAssertions {
+	private static Path tmpDir;
+
+	private FileResourceProvider provider;
+
+	@BeforeAll
+	public static void setupTestFiles(@TempDir Path tmpDir) throws IOException {
+		for (int i = 0; i < 10; i++) {
+			Files.write(tmpDir.resolve("f" + i + ".txt"), ("content#" + i).getBytes());
+		}
+		for (int i = 0; i < 10; i++) {
+			Files.createDirectory(tmpDir.resolve("d" + i));
+		}
+		for (int i = 0; i < 10; i++) {
+			Files.write(tmpDir.resolve("d" + i)
+					.resolve("f" + i + ".txt"), ("xxx#" + i).getBytes());
+		}
+		FileResourceProviderTest.tmpDir = tmpDir;
+	}
+
+	@BeforeEach
+	public void init() {
+		provider = new FileResourceProvider();
+	}
+
+	public ListAssert<String> assertGlob(String glob) {
+		return assertThat(provider.read(URIish.create(tmpDir.toString() + glob)));
+	}
+
+	@Test
+	public void realFiles() {
+		assertGlob("/f[13].txt").containsExactly("content#1", "content#3");
+		assertGlob("/**1.txt").containsExactly("content#1", "xxx#1");
+		assertGlob("/d2/*").containsExactly("xxx#2");
+		assertGlob("/*/f1.txt").containsExactly("xxx#1");
+		assertGlob("/**").contains("xxx#9", "content#1"); // and more
+	}
+
+	@Test
+	public void searchOnlyPossibleMatches() {
+		provider.setMaxFilesTraversed(11); // it shouldn't search through all 20 files now:
+		assertGlob("/*1.txt").containsExactly("content#1");
+	}
+
+	@Test
+	public void maxFilesTraversed(@TempDir Path tmpDir) {
+		provider.setMaxFilesTraversed(15);
+		URIish urIish = URIish.create(tmpDir.toString() + "/**");
+		assertThatThrownBy(() -> provider.read(urIish)).isInstanceOf(ConfijSourceException.class)
+				.hasMessageContaining("traversed too many files");
+	}
+
+	@Test
+	public void maxFileMatches(@TempDir Path tmpDir) {
+		provider.setMaxFileMatches(1);
+		URIish urIish = URIish.create(tmpDir.toString() + "/*.txt");
+		assertThatThrownBy(() -> provider.read(urIish)).isInstanceOf(ConfijSourceException.class)
+				.hasMessageContaining("found too many files");
+	}
+}

--- a/confij-documentation/src/test/java/ch/kk7/confij/docs/DocTestBase.java
+++ b/confij-documentation/src/test/java/ch/kk7/confij/docs/DocTestBase.java
@@ -1,6 +1,6 @@
 package ch.kk7.confij.docs;
 
-import ch.kk7.confij.source.resource.ClasspathResourceProvider;
+import ch.kk7.confij.source.ConfijSourceBuilder.URIish;import ch.kk7.confij.source.resource.ClasspathResourceProvider;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -18,6 +18,6 @@ public abstract class DocTestBase implements WithAssertions {
 	}
 
 	public static String classpath(String file) {
-		return new ClasspathResourceProvider().read(URI.create(file)).findAny().orElseThrow(IllegalStateException::new);
+		return new ClasspathResourceProvider().read(URIish.create(file)).findAny().orElseThrow(IllegalStateException::new);
 	}
 }

--- a/confij-documentation/src/test/java/ch/kk7/confij/docs/DocTestBase.java
+++ b/confij-documentation/src/test/java/ch/kk7/confij/docs/DocTestBase.java
@@ -18,6 +18,6 @@ public abstract class DocTestBase implements WithAssertions {
 	}
 
 	public static String classpath(String file) {
-		return new ClasspathResourceProvider().read(URI.create(file));
+		return new ClasspathResourceProvider().read(URI.create(file)).findAny().orElseThrow(IllegalStateException::new);
 	}
 }

--- a/confij-documentation/src/test/java/ch/kk7/confij/docs/Source.java
+++ b/confij-documentation/src/test/java/ch/kk7/confij/docs/Source.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
+import java.util.UUID;import java.util.stream.Stream;
 
 public class Source extends DocTestBase {
 	// tag::interface[]
@@ -200,7 +200,7 @@ public class Source extends DocTestBase {
 	// tag::resourceprovider-service-ignored[]
 	public static class AnUnimportantFooProvider extends FooProvider implements ServiceLoaderPriority {
 		@Override
-		public String read(URI path) {
+		public Stream<String> read(URI path) {
 			throw new RuntimeException("less important than " + FooProvider.class);
 		}
 
@@ -216,8 +216,8 @@ public class Source extends DocTestBase {
 	// +file: META-INF/services/ch.kk7.confij.source.file.resource.ConfijResourceProvider
 	public static class FooProvider implements ConfijResourceProvider {
 		@Override
-		public String read(URI path) {
-			return "foo=bar";
+		public Stream<String> read(URI path) {
+			return Stream.of("foo=bar");
 		}
 
 		@Override

--- a/confij-documentation/src/test/java/ch/kk7/confij/docs/Source.java
+++ b/confij-documentation/src/test/java/ch/kk7/confij/docs/Source.java
@@ -5,13 +5,12 @@ import ch.kk7.confij.annotation.Default;
 import ch.kk7.confij.annotation.Key;
 import ch.kk7.confij.common.ServiceLoaderPriority;
 import ch.kk7.confij.common.ServiceLoaderUtil;
-import ch.kk7.confij.source.resource.ConfijResourceProvider;
+import ch.kk7.confij.source.ConfijSourceBuilder.URIish;import ch.kk7.confij.source.resource.ConfijResourceProvider;
 import com.github.stefanbirkner.systemlambda.SystemLambda;
 import com.google.auto.service.AutoService;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -200,7 +199,7 @@ public class Source extends DocTestBase {
 	// tag::resourceprovider-service-ignored[]
 	public static class AnUnimportantFooProvider extends FooProvider implements ServiceLoaderPriority {
 		@Override
-		public Stream<String> read(URI path) {
+		public Stream<String> read(URIish path) {
 			throw new RuntimeException("less important than " + FooProvider.class);
 		}
 
@@ -216,12 +215,12 @@ public class Source extends DocTestBase {
 	// +file: META-INF/services/ch.kk7.confij.source.file.resource.ConfijResourceProvider
 	public static class FooProvider implements ConfijResourceProvider {
 		@Override
-		public Stream<String> read(URI path) {
+		public Stream<String> read(URIish path) {
 			return Stream.of("foo=bar");
 		}
 
 		@Override
-		public boolean canHandle(URI path) {
+		public boolean canHandle(URIish path) {
 			return "foo".equals(path.getScheme());
 		}
 	}

--- a/confij-git/src/main/java/ch/kk7/confij/source/resource/GitResourceProvider.java
+++ b/confij-git/src/main/java/ch/kk7/confij/source/resource/GitResourceProvider.java
@@ -1,6 +1,7 @@
 package ch.kk7.confij.source.resource;
 
 import ch.kk7.confij.logging.ConfijLogger;
+import ch.kk7.confij.source.ConfijSourceBuilder;
 import ch.kk7.confij.source.ConfijSourceException;
 import com.google.auto.service.AutoService;
 import lombok.Builder;
@@ -28,7 +29,6 @@ import org.eclipse.jgit.treewalk.TreeWalk;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -64,29 +64,30 @@ public class GitResourceProvider extends AbstractResourceProvider {
 		TransportConfigCallback transportConfigCallback;
 	}
 
-	public static URI toUri(String remoteUri, String configFile) {
+	public static ConfijSourceBuilder.URIish toUri(String remoteUri, String configFile) {
 		return toUri(remoteUri, configFile, null);
 	}
 
-	public static URI toUri(@NonNull String remoteUri, @NonNull String configFile, String gitRevision) {
+	public static ConfijSourceBuilder.URIish toUri(@NonNull String remoteUri, @NonNull String configFile, String gitRevision) {
 		configFile = configFile.startsWith("/") ? configFile.substring(1) : configFile;
 		String urlFileSep = remoteUri.matches(".*\\.git/?$") ? "/" : "//";
-		return URI.create(SCHEME + ":" + remoteUri + urlFileSep + configFile + (gitRevision == null ? "" : "#" + gitRevision));
+		return ConfijSourceBuilder.URIish.create(
+				SCHEME + ":" + remoteUri + urlFileSep + configFile + (gitRevision == null ? "" : "#" + gitRevision));
 	}
 
 	@Override
-	public Stream<String> read(URI path) {
+	public Stream<String> read(ConfijSourceBuilder.URIish path) {
 		GitSettings settings = uriToGitSettings(path);
 		Git git = gitCloneOrFetch(settings);
 		return Stream.of(readFile(git, settings));
 	}
 
 	@Override
-	public boolean canHandle(URI path) {
+	public boolean canHandle(ConfijSourceBuilder.URIish path) {
 		return SCHEME.equals(path.getScheme());
 	}
 
-	protected GitSettings uriToGitSettings(URI uri) {
+	protected GitSettings uriToGitSettings(ConfijSourceBuilder.URIish uri) {
 		String urlAndFile = uri.getSchemeSpecificPart();
 		Matcher m = URL_FILE_SPLITTER.matcher(urlAndFile);
 		if (!m.matches()) {
@@ -154,7 +155,7 @@ public class GitResourceProvider extends AbstractResourceProvider {
 		}
 	}
 
-	protected Git gitFetch(Git git, GitSettings settings) throws GitAPIException, IOException {
+	protected Git gitFetch(Git git, GitSettings settings) throws GitAPIException {
 		LOGGER.debug("git fetch: {}", settings);
 		FetchResult fetchResult = git.fetch()
 				.setRemote(settings.getRemoteUrl())

--- a/confij-git/src/main/java/ch/kk7/confij/source/resource/GitResourceProvider.java
+++ b/confij-git/src/main/java/ch/kk7/confij/source/resource/GitResourceProvider.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static ch.kk7.confij.common.Util.not;
 
@@ -74,10 +75,10 @@ public class GitResourceProvider extends AbstractResourceProvider {
 	}
 
 	@Override
-	public String read(URI path) {
+	public Stream<String> read(URI path) {
 		GitSettings settings = uriToGitSettings(path);
 		Git git = gitCloneOrFetch(settings);
-		return readFile(git, settings);
+		return Stream.of(readFile(git, settings));
 	}
 
 	@Override
@@ -197,7 +198,7 @@ public class GitResourceProvider extends AbstractResourceProvider {
 		try {
 			objectId = repository.resolve(settings.getGitRevision());
 		} catch (Exception e) {
-			throw new ConfijSourceException("failed to git resove revision {} ({})", settings.getGitRevision(), settings, e);
+			throw new ConfijSourceException("failed to git resove an objectId from rev {} ({})", settings.getGitRevision(), settings, e);
 		}
 		if (objectId == null) {
 			throw new ConfijSourceException("unable to git resove revision {} ({})", settings.getGitRevision(), settings);

--- a/confij-git/src/test/java/ch/kk7/confij/source/resource/ExplicitSshKeyGitResourceProvider.java
+++ b/confij-git/src/test/java/ch/kk7/confij/source/resource/ExplicitSshKeyGitResourceProvider.java
@@ -1,5 +1,6 @@
 package ch.kk7.confij.source.resource;
 
+import ch.kk7.confij.source.ConfijSourceBuilder;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
@@ -10,7 +11,6 @@ import org.eclipse.jgit.transport.SshTransport;
 import org.eclipse.jgit.util.FS;
 
 import java.io.File;
-import java.net.URI;
 
 @AllArgsConstructor
 public class ExplicitSshKeyGitResourceProvider extends GitResourceProvider {
@@ -18,7 +18,7 @@ public class ExplicitSshKeyGitResourceProvider extends GitResourceProvider {
 	private final File knownHostsFile;
 
 	@Override
-	protected GitSettings uriToGitSettings(URI uri) {
+	protected GitSettings uriToGitSettings(ConfijSourceBuilder.URIish uri) {
 		return super.uriToGitSettings(uri)
 				.withTransportConfigCallback(transport -> {
 					SshTransport sshTransport = (SshTransport) transport;

--- a/confij-git/src/test/java/ch/kk7/confij/source/resource/GitResourceProviderHttpTest.java
+++ b/confij-git/src/test/java/ch/kk7/confij/source/resource/GitResourceProviderHttpTest.java
@@ -43,14 +43,20 @@ public class GitResourceProviderHttpTest implements WithAssertions {
 		server.stop();
 	}
 
+	private String gitRead(URI uri) {
+		return git.read(uri)
+				.findAny()
+				.orElseThrow(IllegalStateException::new);
+	}
+
 	@Test
 	void basicAuthOverHttp() throws Exception {
 		testGit.addAndCommit();
 		RevCommit commit2 = testGit.addAndCommit();
-		assertThat(git.read(httpUri)).isEqualTo(commit2.getShortMessage());
+		assertThat(gitRead(httpUri)).isEqualTo(commit2.getShortMessage());
 
 		RevCommit commit3 = testGit.addAndCommit();
-		assertThat(git.read(httpUri)).isEqualTo(commit3.getShortMessage());
+		assertThat(gitRead(httpUri)).isEqualTo(commit3.getShortMessage());
 	}
 
 	@Test
@@ -66,7 +72,7 @@ public class GitResourceProviderHttpTest implements WithAssertions {
 	@Test
 	void httpsFailsDueToCerts() throws Exception {
 		testGit.addAndCommit();
-		assertThatThrownBy(() -> git.read(httpsUri)).isInstanceOf(ConfijSourceException.class)
+		assertThatThrownBy(() -> gitRead(httpsUri)).isInstanceOf(ConfijSourceException.class)
 				.hasStackTraceContaining("cert");
 	}
 
@@ -75,10 +81,10 @@ public class GitResourceProviderHttpTest implements WithAssertions {
 		git = new NoSslVerifyGitResourceProvider();
 		testGit.addAndCommit();
 		RevCommit commit2 = testGit.addAndCommit();
-		assertThat(git.read(httpUri)).isEqualTo(commit2.getShortMessage());
+		assertThat(gitRead(httpUri)).isEqualTo(commit2.getShortMessage());
 
 		RevCommit commit3 = testGit.addAndCommit();
-		assertThat(git.read(httpUri)).isEqualTo(commit3.getShortMessage());
+		assertThat(gitRead(httpUri)).isEqualTo(commit3.getShortMessage());
 	}
 
 	@Disabled("since it is a remote repo")
@@ -86,8 +92,8 @@ public class GitResourceProviderHttpTest implements WithAssertions {
 	public void cloneGithubTestrepo() {
 		// not private accessable "ssh://git@github.com/github/testrepo.git"
 		URI uri = GitResourceProvider.toUri("https://github.com/github/testrepo.git", "test/alloc.c");
-		assertThat(git.read(uri)).contains("Linus Torvalds");
+		assertThat(gitRead(uri)).contains("Linus Torvalds");
 		// once more: expecting a fetch instead of clone
-		assertThat(git.read(uri)).contains("Linus Torvalds");
+		assertThat(gitRead(uri)).contains("Linus Torvalds");
 	}
 }

--- a/confij-git/src/test/java/ch/kk7/confij/source/resource/GitResourceProviderHttpTest.java
+++ b/confij-git/src/test/java/ch/kk7/confij/source/resource/GitResourceProviderHttpTest.java
@@ -1,5 +1,6 @@
 package ch.kk7.confij.source.resource;
 
+import ch.kk7.confij.source.ConfijSourceBuilder;
 import ch.kk7.confij.source.ConfijSourceException;
 import org.assertj.core.api.WithAssertions;
 import org.eclipse.jgit.api.errors.TransportException;
@@ -13,14 +14,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
-import java.net.URI;
 
 public class GitResourceProviderHttpTest implements WithAssertions {
 	private GitResourceProvider git;
 	private GitTestrepo testGit;
 	private SimpleHttpServer server;
-	private URI httpUri;
-	private URI httpsUri;
+	private ConfijSourceBuilder.URIish httpUri;
+	private ConfijSourceBuilder.URIish httpsUri;
 
 	@BeforeEach
 	public void initServer(@TempDir File tempDir) throws Exception {
@@ -43,7 +43,7 @@ public class GitResourceProviderHttpTest implements WithAssertions {
 		server.stop();
 	}
 
-	private String gitRead(URI uri) {
+	private String gitRead(ConfijSourceBuilder.URIish uri) {
 		return git.read(uri)
 				.findAny()
 				.orElseThrow(IllegalStateException::new);
@@ -60,8 +60,8 @@ public class GitResourceProviderHttpTest implements WithAssertions {
 	}
 
 	@Test
-	void invalidPassword() throws Exception {
-		URI invalidPasswordUri = GitResourceProvider.toUri(server.getUri()
+	void invalidPassword() {
+		ConfijSourceBuilder.URIish invalidPasswordUri = GitResourceProvider.toUri(server.getUri()
 				.setUser(AppServer.username)
 				.setPass("totallyWrongPassword")
 				.toPrivateString(), GitTestrepo.DEFAULT_FILE);
@@ -91,7 +91,7 @@ public class GitResourceProviderHttpTest implements WithAssertions {
 	@Test
 	public void cloneGithubTestrepo() {
 		// not private accessable "ssh://git@github.com/github/testrepo.git"
-		URI uri = GitResourceProvider.toUri("https://github.com/github/testrepo.git", "test/alloc.c");
+		ConfijSourceBuilder.URIish uri = GitResourceProvider.toUri("https://github.com/github/testrepo.git", "test/alloc.c");
 		assertThat(gitRead(uri)).contains("Linus Torvalds");
 		// once more: expecting a fetch instead of clone
 		assertThat(gitRead(uri)).contains("Linus Torvalds");

--- a/confij-git/src/test/java/ch/kk7/confij/source/resource/GitResourceProviderSshTest.java
+++ b/confij-git/src/test/java/ch/kk7/confij/source/resource/GitResourceProviderSshTest.java
@@ -1,5 +1,6 @@
 package ch.kk7.confij.source.resource;
 
+import ch.kk7.confij.source.ConfijSourceBuilder;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.KeyPair;
 import org.assertj.core.api.WithAssertions;
@@ -15,7 +16,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collections;
@@ -27,7 +27,7 @@ public class GitResourceProviderSshTest implements WithAssertions {
 	private GitTestrepo testGit;
 	protected static final String TEST_USER = "testuser";
 	private SshTestGitServer server;
-	private URI sshUri;
+	private ConfijSourceBuilder.URIish sshUri;
 
 	private static byte[] createHostKey(OutputStream publicKey) throws Exception {
 		JSch jsch = new JSch();
@@ -80,7 +80,7 @@ public class GitResourceProviderSshTest implements WithAssertions {
 		server.stop();
 	}
 
-	private String gitRead(URI uri) {
+	private String gitRead(ConfijSourceBuilder.URIish uri) {
 		return git.read(uri)
 				.findAny()
 				.orElseThrow(IllegalStateException::new);

--- a/confij-git/src/test/java/ch/kk7/confij/source/resource/GitResourceProviderSshTest.java
+++ b/confij-git/src/test/java/ch/kk7/confij/source/resource/GitResourceProviderSshTest.java
@@ -80,10 +80,16 @@ public class GitResourceProviderSshTest implements WithAssertions {
 		server.stop();
 	}
 
+	private String gitRead(URI uri) {
+		return git.read(uri)
+				.findAny()
+				.orElseThrow(IllegalStateException::new);
+	}
+
 	@Test
 	public void viaSshUserAndPK() throws Exception {
 		testGit.addAndCommit();
 		RevCommit commit2 = testGit.addAndCommit();
-		assertThat(git.read(sshUri)).isEqualTo(commit2.getShortMessage());
+		assertThat(gitRead(sshUri)).isEqualTo(commit2.getShortMessage());
 	}
 }

--- a/confij-hocon/src/main/java/ch/kk7/confij/source/format/HoconResourceProvider.java
+++ b/confij-hocon/src/main/java/ch/kk7/confij/source/format/HoconResourceProvider.java
@@ -1,12 +1,12 @@
 package ch.kk7.confij.source.format;
 
 import ch.kk7.confij.logging.ConfijLogger;
+import ch.kk7.confij.source.ConfijSourceBuilder.URIish;
 import ch.kk7.confij.tree.ConfijNode;
 import com.google.auto.service.AutoService;
 import com.typesafe.config.ConfigFactory;
 import lombok.ToString;
 
-import java.net.URI;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -78,7 +78,7 @@ public class HoconResourceProvider implements ConfijSourceFormat {
 	}
 
 	@Override
-	public boolean canHandle(URI path) {
+	public boolean canHandle(URIish path) {
 		return path.getSchemeSpecificPart()
 				.matches("(?s).+\\.(json|hocon|conf)$");
 	}

--- a/confij-toml/src/main/java/ch/kk7/confij/source/format/TomlFormat.java
+++ b/confij-toml/src/main/java/ch/kk7/confij/source/format/TomlFormat.java
@@ -1,17 +1,6 @@
 package ch.kk7.confij.source.format;
 
-import static ch.kk7.confij.source.format.ConfijSourceFormatException.invalidFormat;
-import static java.util.stream.Collectors.joining;
-
-import java.net.URI;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.OffsetDateTime;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
-
+import ch.kk7.confij.source.ConfijSourceBuilder.URIish;
 import ch.kk7.confij.tree.ConfijNode;
 import com.google.auto.service.AutoService;
 import lombok.ToString;
@@ -20,6 +9,17 @@ import org.tomlj.TomlArray;
 import org.tomlj.TomlParseError;
 import org.tomlj.TomlParseResult;
 import org.tomlj.TomlTable;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static ch.kk7.confij.source.format.ConfijSourceFormatException.invalidFormat;
+import static java.util.stream.Collectors.joining;
 
 @ToString
 @AutoService(ConfijSourceFormat.class)
@@ -110,7 +110,8 @@ public class TomlFormat implements ConfijSourceFormat {
 	}
 
 	@Override
-	public boolean canHandle(URI path) {
-		return path.getSchemeSpecificPart().matches("(?i).+\\.toml$");
+	public boolean canHandle(URIish path) {
+		return path.getSchemeSpecificPart()
+				.matches("(?i).+\\.toml$");
 	}
 }

--- a/confij-yaml/src/main/java/ch/kk7/confij/source/format/YamlFormat.java
+++ b/confij-yaml/src/main/java/ch/kk7/confij/source/format/YamlFormat.java
@@ -1,16 +1,6 @@
 package ch.kk7.confij.source.format;
 
-import static ch.kk7.confij.source.format.ConfijSourceFormatException.invalidFormat;
-
-import java.net.URI;
-import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Date;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Map;
-
+import ch.kk7.confij.source.ConfijSourceBuilder.URIish;
 import ch.kk7.confij.tree.ConfijNode;
 import com.google.auto.service.AutoService;
 import lombok.NonNull;
@@ -19,6 +9,16 @@ import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.Tag;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+
+import static ch.kk7.confij.source.format.ConfijSourceFormatException.invalidFormat;
 
 @ToString
 @AutoService(ConfijSourceFormat.class)
@@ -105,7 +105,7 @@ public class YamlFormat implements ConfijSourceFormat {
 	}
 
 	@Override
-	public boolean canHandle(URI path) {
+	public boolean canHandle(URIish path) {
 		return path.getSchemeSpecificPart()
 				.matches("(?i).+\\.ya?ml$");
 	}

--- a/confij-yaml/src/test/java/ch/kk7/confij/source/format/YamlFormatCanHandleTest.java
+++ b/confij-yaml/src/test/java/ch/kk7/confij/source/format/YamlFormatCanHandleTest.java
@@ -1,17 +1,16 @@
 package ch.kk7.confij.source.format;
 
+import ch.kk7.confij.source.ConfijSourceBuilder.URIish;
 import org.assertj.core.api.AbstractBooleanAssert;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import java.net.URI;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class YamlFormatCanHandleTest {
 
 	public static AbstractBooleanAssert<?> assertCanHandle(String file) {
-		return assertThat(new YamlFormat().canHandle(URI.create(file)));
+		return assertThat(new YamlFormat().canHandle(URIish.create(file)));
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
Support glob expressions in file sources, like `some/path/*.txt`. It's generally a tricky topic to not search too many file nodes but still find all matching files (think of **/). There are some safety nets in place to prevent searching though too many filenames.
API change for ConfijSource and alike: dropped the URI in favour of a URIish which doesn't have any encoding restrictions.
Minor: fixed a crash when reading an empty file.

Fixes #13 