### PR TITLE
sonatype autopublish

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,19 +34,10 @@ jobs:
           key: gradle-${{ runner.os }}-${{ matrix.java }}-pr
 
       - name: build 🔧
-        run: ./gradlew -s build
+        run: ./gradlew -s build publishToMavenLocal
 
       - name: sonar ⛅️
         run: ./gradlew -s sonarqube
         if: ${{ matrix.sonar }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-      - name: publish snapshot 📤
-        run: ./gradlew -s publish
-        if: ${{ matrix.sonar }}
-        env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SONATYPE_SIGNKEY: ${{ secrets.SONATYPE_SIGNKEY }}
-          SONATYPE_SIGNPASS: ${{ secrets.SONATYPE_SIGNPASS }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: publish 📤
-        run: ./gradlew -s publish
+        run: ./gradlew -s publishToSonatype closeAndReleaseRepository
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -168,6 +168,13 @@ project.tasks['sonarqube'].dependsOn jacocoRootReport
 def isRemotePublish = System.getenv('CI') != null && System.getenv('SONATYPE_USERNAME') != null
 if (isRemotePublish) {
 	logger.lifecycle("remote publishing is enabled");
+	closeAndReleaseRepository.enabled !version.toString().endsWith("-SNAPSHOT")
+	nexusStaging {
+		username = System.getenv('SONATYPE_USERNAME')
+		password = System.getenv('SONATYPE_PASSWORD')
+		numberOfRetries = 60
+		delayBetweenRetriesInMillis = 5000
+	}
 }
 subprojects {
 	if (sourceSets.main.allSource.isEmpty()) {
@@ -206,8 +213,6 @@ subprojects {
 		}
 	}
 	if (isRemotePublish) {
-		closeAndReleaseRepository.enabled !version.toString().endsWith("-SNAPSHOT")
-
 		apply plugin: 'de.marcphilipp.nexus-publish'
 		nexusPublishing {
 			repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,8 @@ plugins {
 	id 'org.sonarqube' version '3.0'
 	id 'org.asciidoctor.jvm.convert' version '3.2.0' apply false
 	id 'com.github.johnrengelman.shadow' version '6.0.0' apply false
+	id 'de.marcphilipp.nexus-publish' version '0.4.0' apply false
+	id 'io.codearte.nexus-staging' version '0.22.0'
 }
 
 reckon {
@@ -202,22 +204,20 @@ subprojects {
 				}
 			}
 		}
-		if (isRemotePublish) {
+	}
+	if (isRemotePublish) {
+		closeAndReleaseRepository.enabled !version.toString().endsWith("-SNAPSHOT")
+
+		apply plugin: 'de.marcphilipp.nexus-publish'
+		nexusPublishing {
 			repositories {
-				maven {
-					def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-					def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-					def isReleaseBuild = project.version.toString().matches("[0-9.]+") // no "rc" nor "snapshot"
-					url = isReleaseBuild ? releasesRepoUrl : snapshotsRepoUrl
-					credentials {
-						username = System.getenv('SONATYPE_USERNAME')
-						password = System.getenv('SONATYPE_PASSWORD')
-					}
+				sonatype {
+					username = System.getenv('SONATYPE_USERNAME')
+					password = System.getenv('SONATYPE_PASSWORD')
 				}
 			}
 		}
-	}
-	if (isRemotePublish) {
+
 		apply plugin: 'signing'
 		signing {
 			def signingKey = System.getenv('SONATYPE_SIGNKEY')


### PR DESCRIPTION
raw maven-publish is often splitted up in multiple staging repos when CI uses different IPs. this makes it more stable.
additionally only master will publish SNAPSHOT releases now.