### PR TITLE
gradle toolchain for jdk matrix testing

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,6 +11,7 @@ jobs:
       - name: JDK11 ☕
         uses: actions/setup-java@v2
         with:
+          distribution: 'zulu'
           java-version: 11
       - name: build 🔧️
         uses: burrunan/gradle-cache-action@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,43 +1,21 @@
 name: pr
 on: pull_request
-
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [8, 9, 13, 14, 15] # other supported JDK versions
-        sonar: [false]
-        include:
-          - java: 11 # usually latest LTS
-            sonar: true
-      fail-fast: false
     steps:
       - name: checkout 📥
         uses: actions/checkout@v2
         with:
           fetch-depth: 0 # all commits, required for propper versioning
-
-      - name: JDK${{ matrix.java }} ☕
-        uses: actions/setup-java@v1
+      - name: JDK11 ☕
+        uses: actions/setup-java@v2
         with:
-          java-version: ${{ matrix.java }}
-
-      - name: cache 🗂️
-        uses: actions/cache@v2
+          java-version: 11
+      - name: build 🔧️
+        uses: burrunan/gradle-cache-action@v1
         with:
-          path: |
-            ~/.gradle/caches
-            !~/.gradle/caches/modules-2/modules-2.lock
-            !~/.gradle/caches/*/plugin-resolution/
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ matrix.java }}-pr
-
-      - name: build 🔧
-        run: ./gradlew -s build publishToMavenLocal
-
-      - name: sonar ⛅️
-        run: ./gradlew -s sonarqube
-        if: ${{ matrix.sonar }}
+          job-id: jdk11
+          arguments: -s --console=plain build publishToMavenLocal sonarqube
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,10 @@
 name: release
 on:
   push:
-    branches: master
-    tags: '[0-9]+.[0-9]+.[0-9]+*'
-
+    branches:
+      - master
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,39 +13,30 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0 # all commits, required for propper versioning
-
-      - name: setup ☕
-        uses: actions/setup-java@v1
+      - name: JDK11 ☕
+        uses: actions/setup-java@v2
         with:
           java-version: 11
-
-      - name: cache 🗂️
-        uses: actions/cache@v2
+      - name: build 🔧️
+        uses: burrunan/gradle-cache-action@v1
         with:
-          path: |
-            ~/.gradle/caches
-            !~/.gradle/caches/modules-2/modules-2.lock
-            !~/.gradle/caches/*/plugin-resolution/
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ matrix.java }}-master
-
-      - name: build 🔧
-        run: ./gradlew -s build sonarqube
+          job-id: jdk11
+          arguments: -s --console=plain build sonarqube
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # sonar bug: shouldn't be needed
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
       - name: publish 📤
-        run: ./gradlew -s publishToSonatype closeAndReleaseRepository
+        uses: burrunan/gradle-cache-action@v1
+        with:
+          job-id: jdk11
+          arguments: -s --console=plain publishToSonatype closeAndReleaseRepository
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_SIGNKEY: ${{ secrets.SONATYPE_SIGNKEY }}
           SONATYPE_SIGNPASS: ${{ secrets.SONATYPE_SIGNPASS }}
-
       - name: docs 📜
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./confij-documentation/build/docs/asciidoc
-          keep_files: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
       - name: JDK11 ☕
         uses: actions/setup-java@v2
         with:
+          distribution: 'zulu'
           java-version: 11
       - name: build 🔧️
         uses: burrunan/gradle-cache-action@v1

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,16 @@ subprojects {
 		withJavadocJar()
 	}
 
+	[9, 11, 15].forEach(jv -> {
+		def testJava = tasks.register("testJava${jv}", Test) {
+			javaLauncher = javaToolchains.launcherFor {
+				languageVersion = JavaLanguageVersion.of(jv)
+			}
+			shouldRunAfter 'test'
+		}
+		check.dependsOn testJava
+	})
+
 	tasks.withType(JavaCompile) {
 		options.incremental = true
 	}
@@ -107,15 +117,16 @@ subprojects {
 		testRuntimeOnly 'ch.qos.logback:logback-classic:1.2.3'
 	}
 
-	test {
+	tasks.withType(Test) {
 		useJUnitPlatform() // junit5 support
-		if (System.getenv('CI') != null) {
+		if (System.getenv().containsKey("CI")) {
 			testLogging {
 				events "passed", "skipped", "failed"
 				exceptionFormat "full"
 			}
 		}
 	}
+
 	configurations { // allow test reuse
 		testOutput.extendsFrom(testImplementation)
 	}

--- a/confij-documentation/build.gradle
+++ b/confij-documentation/build.gradle
@@ -30,6 +30,6 @@ asciidoctor {
 
 tasks.assemble.dependsOn 'asciidoctor'
 
-test {
+tasks.withType(Test) {
 	workingDir file('src/test/home')
 }

--- a/confij-git/build.gradle
+++ b/confij-git/build.gradle
@@ -8,8 +8,8 @@ dependencies {
 	testImplementation "org.eclipse.jgit:org.eclipse.jgit.junit.ssh:${gitVersion}"
 }
 
-test {
-	javaLauncher = javaToolchains.launcherFor {
-		languageVersion = JavaLanguageVersion.of(15) // newer JDK required for jetty keystore
-	}
+// test-git-jetty requires a reasonably new JDK for key management
+tasks.withType(Test) {
+	enabled = false
 }
+testJava15.enabled = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,5 @@ org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xms256m -Xmx512m -XX:MaxPermSize=256M
+org.gradle.caching=true
 reckon.scope=patch


### PR DESCRIPTION
test supported JDK versions using different gradle toolchains, such that this tests are also run on dev machines.
improve on CI gradle caching.